### PR TITLE
Remove create_environment_oidc_connection and update_environment_oidc_connection tools

### DIFF
--- a/src/tools/connections.ts
+++ b/src/tools/connections.ts
@@ -9,12 +9,11 @@ import {
   ConnectedAccount,
   Connection,
   CreateConnectedAccountMagicLinkResponse,
-  CreateConnectionResponse,
   EnableConnectionResponse,
   ListConnectedAccountsResponse,
   ListConnectionsResponse,
 } from '../types/index.js';
-import { connectionIdSchema, environmentIdSchema, oidcProviderSchema, organizationIdSchema, validateUrls } from '../validators/types.js';
+import { connectionIdSchema, environmentIdSchema, organizationIdSchema } from '../validators/types.js';
 import { TOOLS } from './index.js';
 
 function formatConnections(connections: Connection[]): string {
@@ -60,8 +59,6 @@ export function registerConnectionTools(server: McpServer){
   TOOLS.list_connected_accounts.registeredTool = listConnectedAccountsTool(server);
   TOOLS.create_connected_account_magic_link.registeredTool = createConnectedAccountMagicLinkTool(server);
   TOOLS.list_organization_connections.registeredTool = getOrganizationConnectionsTool(server);
-  TOOLS.create_environment_oidc_connection.registeredTool = createEnvironmentOidcConnectionTool(server);
-  TOOLS.update_environment_oidc_connection.registeredTool = updateEnvironmentOidcConnectionTool(server);
   TOOLS.enable_environment_connection.registeredTool = enableConnectionTool(server);
 }
 
@@ -240,181 +237,6 @@ function getOrganizationConnectionsTool(server: McpServer): RegisteredTool {
       }
     }
   );
-}
-
-function createEnvironmentOidcConnectionTool(server: McpServer): RegisteredTool {
-  return server.tool(
-    TOOLS.create_environment_oidc_connection.name,
-    TOOLS.create_environment_oidc_connection.description,
-    {
-      environmentId: environmentIdSchema,
-      provider: oidcProviderSchema,
-    },
-    async ({ environmentId, provider }, context) => {
-      const authInfo = context.authInfo as AuthInfo;
-      const token = authInfo?.token;
-      const type = 'OIDC';
-
-      try {
-        const environmentDomain = await getEnvironmentDomain(token, environmentId);
-
-        const res = await fetch(`${ENDPOINTS.connections.create}`, {
-          method: 'POST',
-          headers: envHeaders(token, environmentDomain, { 'Content-Type': 'application/json' }),
-          body: JSON.stringify({
-            provider: provider,
-            type: type,
-          }),
-        });
-
-                if (!res.ok) {
-                    const errorText = await res.text();
-                    logger.error(`Failed to create OIDC connection: ${res.status} ${errorText}`);
-                    return {
-                        content: [
-                            {
-                                type: 'text',
-                                text: `Failed to create OIDC connection: ${res.statusText}`,
-                            },
-                        ],
-                    };
-                }
-
-                const connection = await res.json() as CreateConnectionResponse;
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: `OIDC connection created successfully!\n${JSON.stringify(connection, null, 2)}`,
-                        },
-                    ],
-                };
-            } catch (error) {
-                logger.error(`Failed to create OIDC connection`, error);
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: 'Failed to create OIDC connection. Please try again later.',
-                        },
-                    ],
-                };
-            }
-        }
-    );
-}
-
-function updateEnvironmentOidcConnectionTool(server: McpServer): RegisteredTool {
-    return server.tool(
-        TOOLS.update_environment_oidc_connection.name,
-        TOOLS.update_environment_oidc_connection.description,
-        {
-          environmentId: environmentIdSchema,
-          connectionId: connectionIdSchema,
-          type: z.enum(['OIDC']),
-          key_id: z.string().min(1, 'Key ID is required'),
-          provider: oidcProviderSchema,
-            oidc_config: z.object({
-                issuer: z.string().min(1, 'Issuer is required'),
-                discovery_endpoint: z.string().min(1, 'Discovery endpoint is required'),
-                authorize_uri: z.string().min(1, 'Authorize URI is required'),
-                token_uri: z.string().min(1, 'Token URI is required'),
-                user_info_uri: z.string().min(1, 'User info URI is required'),
-                jwks_uri: z.string().min(1, 'JWKS URI is required'),
-                client_id: z.string(),
-                client_secret: z.string(),
-                scopes: z.array(z.string()),
-                token_auth_type: z.string(),
-                redirect_uri: z.string().min(1, 'Redirect URI is required'),
-                pkce_enabled: z.boolean(),
-                idp_logout_required: z.boolean(),
-                post_logout_redirect_uri: z.string().min(1, 'Post logout redirect URI is required'),
-                backchannel_logout_redirect_uri: z.string().min(1, 'Backchannel logout redirect URI is required'),
-            }),
-        },
-        async (
-            { environmentId, connectionId, type, key_id, provider, oidc_config },
-            context
-        ) => {
-            const authInfo = context.authInfo as AuthInfo;
-            const token = authInfo?.token;
-
-            var res = validateUrls([
-              oidc_config.issuer,
-              oidc_config.discovery_endpoint,
-              oidc_config.authorize_uri,
-              oidc_config.token_uri,
-              oidc_config.user_info_uri,
-              oidc_config.jwks_uri,
-              oidc_config.redirect_uri,
-              oidc_config.post_logout_redirect_uri,
-              oidc_config.backchannel_logout_redirect_uri,
-            ]);
-
-            if (res !== null) {
-              return {
-                content: [
-                  {
-                    type: 'text',
-                    text: res,
-                  },
-                ],
-              };
-            }
-
-            try {
-                const environmentDomain = await getEnvironmentDomain(token, environmentId);
-
-                const res = await fetch(
-                    `${ENDPOINTS.connections.updateById(connectionId)}`,
-                    {
-                        method: 'PATCH',
-                        headers: envHeaders(token, environmentDomain, { 'Content-Type': 'application/json' }),
-                        body: JSON.stringify({
-                            type,
-                            key_id: key_id.toUpperCase(),
-                            configuration_type: 'DISCOVERY',
-                            provider,
-                            oidc_config,
-                        }),
-                    }
-                );
-
-                if (!res.ok) {
-                    const errorText = await res.text();
-                    logger.error(`Failed to update OIDC connection: ${res.status} ${errorText}`);
-                    return {
-                        content: [
-                            {
-                                type: 'text',
-                                text: `Failed to update OIDC connection: ${res.statusText}`,
-                            },
-                        ],
-                    };
-                }
-
-                const connection = await res.json() as CreateConnectionResponse;
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: `OIDC connection updated successfully!\n  id: ${connection.connection?.id}\n  provider: ${provider}\n  type: ${type}`,
-                        },
-                    ],
-                };
-            } catch (error) {
-                logger.error(`Failed to update OIDC connection`, error);
-                return {
-                    content: [
-                        {
-                            type: 'text',
-                            text: 'Failed to update OIDC connection. Please try again later.',
-                        },
-                    ],
-                };
-            }
-        }
-    );
 }
 
 function enableConnectionTool(server: McpServer): RegisteredTool {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -95,41 +95,6 @@ const toolsList = {
     description: 'List all connection for the selected organization. Requires environmentId parameter (format: env_<number>). The tool also requires organization id to be passed (e.g. org_123) ',
     scopes: [SCOPES.organizationRead],
   },
-  create_environment_oidc_connection: {
-    name: 'create_environment_oidc_connection',
-    description: `Create a new OIDC connection for the specified environment. Requires environmentId parameter (format: env_<number>). This tool is responsible for creating the connection at environment level.
-The tool requires the following parameters:
-- provider: ("OKTA", "GOOGLE", "MICROSOFT_AD", "AUTH0", "ONELOGIN", "PING_IDENTITY", "JUMPCLOUD", "CUSTOM", "GITHUB", "GITLAB", "LINKEDIN", "SALESFORCE", "MICROSOFT", "IDP_SIMULATOR", "SCALEKIT", "ADFS")
-The tool returns the connection details especially redirect_uri which should be used to configure the properties on the IDP side. Ask user to confirm if the redirect uri is configured at the idp end. Once done then come back and give all the details needed for update_environment_connection.
-`,
-    scopes: [SCOPES.environmentWrite],
-  },
-  update_environment_oidc_connection: {
-    name: 'update_environment_oidc_connection',
-    description: `Update an existing OIDC connection for the specified environment. Requires environmentId parameter (format: env_<number>). This tool is responsible for updating the connection at environment level. Ask for all these parameters expicitly always from user
-The tool requires the following parameters:
-- connectionId: (ID of the connection to enable, e.g. conn_123)
-- key_id: (e.g. "GOOGLE", "DESCOPE", "OKTA", etc) - Should be in capital letters always
-- provider: ("OKTA", "GOOGLE", "MICROSOFT_AD", "AUTH0", "ONELOGIN", "PING_IDENTITY", "JUMPCLOUD", "CUSTOM", "GITHUB", "GITLAB", "LINKEDIN", "SALESFORCE", "MICROSOFT", "IDP_SIMULATOR", "SCALEKIT", "ADFS")
-- oidc_config: {
-    issuer: uri,
-    discovery_endpoint: uri,
-    authorize_uri: uri,
-    token_uri: uri,
-    user_info_uri: uri,
-    jwks_uri: uri,
-    client_id: string,
-    client_secret: string,
-    scopes: string[],
-    token_auth_type: uri,
-    redirect_uri: uri,
-    pkce_enabled: boolean,
-    idp_logout_required: boolean,
-    post_logout_redirect_uri: uri,
-    backchannel_logout_redirect_uri: uri,
-    The tool returns the connection details which should be reviewed. Once the user confirms, then invoke enable_environment_connection tool to enable the connection.`,
-    scopes: [SCOPES.environmentWrite],
-  },
   enable_environment_connection: {
     name: 'enable_environment_connection',
     description: `Enable an existing connection for the specified environment. Requires environmentId parameter (format: env_<number>). This tool requires the following parameters:


### PR DESCRIPTION
## Summary

- Removed `create_environment_oidc_connection` tool from tool registry and implementation
- Removed `update_environment_oidc_connection` tool from tool registry and implementation
- Cleaned up unused imports (`oidcProviderSchema`, `validateUrls`, `CreateConnectionResponse`) from `connections.ts`

## Test plan

- [ ] Verify the MCP server starts without errors
- [ ] Confirm neither `create_environment_oidc_connection` nor `update_environment_oidc_connection` appear in the exposed tools list
- [ ] Confirm remaining connection tools (`list_environment_connections`, `list_connected_accounts`, `create_connected_account_magic_link`, `list_organization_connections`, `enable_environment_connection`) still work as expected

https://claude.ai/code/session_01NA33YvknkRTLEGL7mZUGPV