### PR TITLE
feat: add search_connectors and search_tools MCP tools

### DIFF
--- a/src/tools/connections.ts
+++ b/src/tools/connections.ts
@@ -221,7 +221,7 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
     TOOLS.search_connectors.description,
     {
       environmentId: environmentIdSchema,
-      query: z.string().min(1).describe('Search keyword to match against connector name, identifier, description, or categories (e.g. "gmail", "slack", "hubspot").'),
+      query: z.string().min(1).optional().describe('Search keyword to match against connector name, identifier, description, or categories (e.g. "gmail", "slack", "hubspot").'),
       identifier: z.string().optional().describe('Exact provider identifier for a precise lookup (e.g. "GOOGLE_WORKSPACE", "SLACK"). Use "query" for keyword search instead.'),
       providerType: z.enum(['DEFAULT', 'CUSTOM', 'ALL']).optional().default('ALL').describe('Filter by provider type: DEFAULT (built-in), CUSTOM (environment-scoped), or ALL.'),
       pageSize: z.number().int().min(1).max(1000).optional().default(20),
@@ -231,6 +231,17 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
     async ({ environmentId, query, identifier, providerType, pageSize, pageToken, includeSetupStatus }, context) => {
       const authInfo = context.authInfo as AuthInfo;
       const token = authInfo?.token;
+
+      if (!query && !identifier && (!providerType || providerType === 'ALL')) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'At least one search criterion is required: provide a query, identifier, or providerType (DEFAULT or CUSTOM).',
+            },
+          ],
+        };
+      }
 
       try {
         const environmentDomain = await getEnvironmentDomain(token, environmentId);

--- a/src/tools/connections.ts
+++ b/src/tools/connections.ts
@@ -5,11 +5,13 @@ import { envHeaders, getEnvironmentDomain } from '../lib/api.js';
 import { logger } from '../lib/logger.js';
 import { ENDPOINTS } from '../types/endpoints.js';
 import {
+  AppConnection,
   AuthInfo,
   ConnectedAccount,
   Connection,
   CreateConnectedAccountMagicLinkResponse,
   EnableConnectionResponse,
+  ListAppConnectionsResponse,
   ListConnectedAccountsResponse,
   ListConnectionsResponse,
   ListProvidersResponse,
@@ -156,7 +158,7 @@ function listConnectedAccountsTool(server: McpServer): RegisteredTool {
   );
 }
 
-function formatProviders(providers: Provider[]): string {
+function formatProviders(providers: Provider[], setupMap?: Map<string, AppConnection[]>): string {
   return providers
     .map((p) => {
       const details = [
@@ -168,12 +170,40 @@ function formatProviders(providers: Provider[]): string {
         p.is_custom_mcp ? `custom_mcp: true` : null,
         p.coming_soon ? `coming_soon: true` : null,
         p.proxy_enabled ? `proxy_url: ${p.proxy_url}` : null,
-      ]
-        .filter(Boolean)
-        .join(' | ');
-      return `- ${details}`;
+      ];
+      if (setupMap) {
+        const conns = setupMap.get(p.identifier);
+        if (conns?.length) {
+          const summaries = conns.map((c) => `${c.status} (${c.type}, ${c.key_id})`).join('; ');
+          details.push(`setup: ${summaries}`);
+        } else {
+          details.push('setup: not_configured');
+        }
+      }
+      return `- ${details.filter(Boolean).join(' | ')}`;
     })
     .join('\n');
+}
+
+async function fetchAppConnections(token: string, environmentDomain: string): Promise<Map<string, AppConnection[]>> {
+  const params = new URLSearchParams({ page_size: '1000' });
+  const res = await fetch(`${ENDPOINTS.connections.listApp}?${params.toString()}`, {
+    headers: envHeaders(token, environmentDomain),
+  });
+  if (!res.ok) {
+    logger.warn(`Failed to fetch app connections for setup status: ${res.status}`);
+    return new Map();
+  }
+  const data = (await res.json()) as ListAppConnectionsResponse;
+  const map = new Map<string, AppConnection[]>();
+  for (const conn of data.connections ?? []) {
+    const key = conn.provider_key?.split(':')[0];
+    if (!key) continue;
+    const existing = map.get(key) ?? [];
+    existing.push(conn);
+    map.set(key, existing);
+  }
+  return map;
 }
 
 function matchesQuery(provider: Provider, query: string): boolean {
@@ -196,8 +226,9 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
       providerType: z.enum(['DEFAULT', 'CUSTOM', 'ALL']).optional().default('ALL').describe('Filter by provider type: DEFAULT (built-in), CUSTOM (environment-scoped), or ALL.'),
       pageSize: z.number().int().min(1).max(1000).optional().default(20),
       pageToken: z.string().optional().describe('Opaque token from a previous response to fetch the next page.'),
+      includeSetupStatus: z.boolean().optional().default(false).describe('When true, also checks which connectors have been set up (have active connections) in the environment.'),
     },
-    async ({ environmentId, query, identifier, providerType, pageSize, pageToken }, context) => {
+    async ({ environmentId, query, identifier, providerType, pageSize, pageToken, includeSetupStatus }, context) => {
       const authInfo = context.authInfo as AuthInfo;
       const token = authInfo?.token;
 
@@ -214,9 +245,16 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
         if (identifier) params.set('identifier', identifier);
         if (providerType) params.set('filter.provider_type', providerType);
 
-        const res = await fetch(`${ENDPOINTS.providers.list}?${params.toString()}`, {
+        const providersFetch = fetch(`${ENDPOINTS.providers.list}?${params.toString()}`, {
           headers: envHeaders(token, environmentDomain),
         });
+
+        // Fetch app connections in parallel when setup status is requested
+        const setupMapPromise = includeSetupStatus
+          ? fetchAppConnections(token, environmentDomain)
+          : Promise.resolve(undefined);
+
+        const [res, setupMap] = await Promise.all([providersFetch, setupMapPromise]);
 
         if (!res.ok) {
           const errorText = await res.text();
@@ -239,7 +277,7 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
           const page = providers.slice(offset, offset + pageSize);
           const hasMore = offset + pageSize < totalMatches;
 
-          const rows = formatProviders(page);
+          const rows = formatProviders(page, setupMap);
           const range = totalMatches > 0
             ? ` (showing ${offset + 1}–${offset + page.length})`
             : '';
@@ -258,7 +296,7 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
         }
 
         // Non-search paths (identifier exact match or list all): use API-native pagination
-        const rows = formatProviders(providers);
+        const rows = formatProviders(providers, setupMap);
         const count = data.total_size ?? providers.length;
         const pagination = data.next_page_token
           ? `\n\nNext page token: ${data.next_page_token}`

--- a/src/tools/connections.ts
+++ b/src/tools/connections.ts
@@ -36,7 +36,35 @@ function formatConnections(connections: Connection[]): string {
     .join('\n');
 }
 
-function formatConnectedAccounts(accounts: ConnectedAccount[]): string {
+/** Summary format: group connected accounts by connector, show key details per account. */
+function formatConnectedAccountsSummary(accounts: ConnectedAccount[]): string {
+  const grouped = new Map<string, ConnectedAccount[]>();
+  for (const ca of accounts) {
+    const key = ca.provider || ca.connector || 'UNKNOWN';
+    const list = grouped.get(key) ?? [];
+    list.push(ca);
+    grouped.set(key, list);
+  }
+  const sections: string[] = [];
+  for (const [connector, connectorAccounts] of grouped) {
+    const lines = connectorAccounts.map((ca) => {
+      const parts = [
+        ca.identifier,
+        `status: ${ca.status}`,
+        `auth: ${ca.authorization_type}`,
+        ca.connection_id ? `connection: ${ca.connection_id}` : null,
+        ca.last_used_at ? `last_used: ${ca.last_used_at}` : null,
+        ca.token_expires_at ? `token_expires: ${ca.token_expires_at}` : null,
+      ].filter(Boolean).join(' | ');
+      return `  - ${parts}`;
+    });
+    sections.push(`${connector} (${connectorAccounts.length} account${connectorAccounts.length === 1 ? '' : 's'}):\n${lines.join('\n')}`);
+  }
+  return sections.join('\n\n');
+}
+
+/** Full format: all fields per account, flat list. */
+function formatConnectedAccountsFull(accounts: ConnectedAccount[]): string {
   return accounts
     .map((ca) => {
       const details = [
@@ -105,10 +133,25 @@ function listConnectedAccountsTool(server: McpServer): RegisteredTool {
     TOOLS.list_connected_accounts.description,
     {
       environmentId: environmentIdSchema,
+      connector: z
+        .string()
+        .optional()
+        .describe('Filter by connector type (e.g. "HUBSPOT", "GMAIL", "NOTION").'),
+      connectionId: z
+        .string()
+        .optional()
+        .describe('Filter by a specific connection ID to see only accounts linked to that connection.'),
+      summary: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe(
+          'When true (default), returns accounts grouped by connector with key details. Set to false for full account details.'
+        ),
       pageSize: z.number().int().min(1).max(100).optional().default(20),
-      pageToken: z.string().optional().describe('Opaque token from a previous response next_page_token to fetch the next page.'),
+      pageToken: z.string().optional().describe('Opaque token from a previous response to fetch the next page.'),
     },
-    async ({ environmentId, pageSize, pageToken }, context) => {
+    async ({ environmentId, connector, connectionId, summary, pageSize, pageToken }, context) => {
       const authInfo = context.authInfo as AuthInfo;
       const token = authInfo?.token;
 
@@ -128,18 +171,42 @@ function listConnectedAccountsTool(server: McpServer): RegisteredTool {
         }
 
         const data = (await res.json()) as ListConnectedAccountsResponse;
-        const accounts = data.connected_accounts ?? [];
-        const rows = formatConnectedAccounts(accounts);
+        let accounts = data.connected_accounts ?? [];
+
+        // Client-side filtering
+        if (connector) {
+          const upper = connector.toUpperCase();
+          accounts = accounts.filter(
+            (ca) => ca.provider?.toUpperCase() === upper || ca.connector?.toUpperCase() === upper
+          );
+        }
+        if (connectionId) {
+          accounts = accounts.filter((ca) => ca.connection_id === connectionId);
+        }
+
+        const body = summary
+          ? formatConnectedAccountsSummary(accounts)
+          : formatConnectedAccountsFull(accounts);
+
         const pagination = data.next_page_token
           ? `\n\nNext page token: ${data.next_page_token}`
-          : '\n\nNo more pages.';
-        const prev = data.prev_page_token ? `\nPrevious page token: ${data.prev_page_token}` : '';
+          : '';
+        const prev = data.prev_page_token
+          ? `\nPrevious page token: ${data.prev_page_token}`
+          : '';
+
+        const filterDesc = [
+          connector ? `connector=${connector}` : null,
+          connectionId ? `connection=${connectionId}` : null,
+        ]
+          .filter(Boolean)
+          .join(', ');
 
         return {
           content: [
             {
-              type: 'text',
-              text: `Total connected accounts: ${data.total_size ?? accounts.length}\n\n${rows || '(none)'}${pagination}${prev}`,
+              type: 'text' as const,
+              text: `Connected accounts${filterDesc ? ` (${filterDesc})` : ''} — ${accounts.length} found\n\n${body || '(no connected accounts found)'}${pagination}${prev}`,
             },
           ],
         };

--- a/src/tools/connections.ts
+++ b/src/tools/connections.ts
@@ -12,7 +12,8 @@ import {
   EnableConnectionResponse,
   ListConnectedAccountsResponse,
   ListConnectionsResponse,
-  SearchConnectedAccountsResponse,
+  ListProvidersResponse,
+  Provider,
 } from '../types/index.js';
 import { connectionIdSchema, environmentIdSchema, organizationIdSchema } from '../validators/types.js';
 import { TOOLS } from './index.js';
@@ -155,31 +156,53 @@ function listConnectedAccountsTool(server: McpServer): RegisteredTool {
   );
 }
 
+function formatProviders(providers: Provider[]): string {
+  return providers
+    .map((p) => {
+      const details = [
+        `identifier: ${p.identifier}`,
+        `display_name: ${p.display_name}`,
+        p.description ? `description: ${p.description}` : null,
+        p.categories?.length ? `categories: ${p.categories.join(', ')}` : null,
+        p.is_custom ? `custom: true` : null,
+        p.is_custom_mcp ? `custom_mcp: true` : null,
+        p.coming_soon ? `coming_soon: true` : null,
+        p.proxy_enabled ? `proxy_url: ${p.proxy_url}` : null,
+      ]
+        .filter(Boolean)
+        .join(' | ');
+      return `- ${details}`;
+    })
+    .join('\n');
+}
+
 function searchConnectorsTool(server: McpServer): RegisteredTool {
   return server.tool(
     TOOLS.search_connectors.name,
     TOOLS.search_connectors.description,
     {
       environmentId: environmentIdSchema,
-      query: z.string().min(3, 'Query must be at least 3 characters'),
-      connectionId: connectionIdSchema.optional().describe('Optional connection ID to narrow results to a specific connection.'),
+      identifier: z.string().optional().describe('Exact provider identifier to look up (e.g. "google_workspace", "slack").'),
+      providerType: z.enum(['DEFAULT', 'CUSTOM', 'ALL']).optional().default('ALL').describe('Filter by provider type: DEFAULT (built-in), CUSTOM (environment-scoped), or ALL.'),
       pageSize: z.number().int().min(1).max(30).optional().default(20),
       pageToken: z.string().optional().describe('Opaque token from a previous response to fetch the next page.'),
     },
-    async ({ environmentId, query, connectionId, pageSize, pageToken }, context) => {
+    async ({ environmentId, identifier, providerType, pageSize, pageToken }, context) => {
       const authInfo = context.authInfo as AuthInfo;
       const token = authInfo?.token;
 
       try {
         const environmentDomain = await getEnvironmentDomain(token, environmentId);
         const params = new URLSearchParams({
-          query,
           page_size: String(pageSize),
         });
         if (pageToken) params.set('page_token', pageToken);
-        if (connectionId) params.set('connection_id', connectionId);
+        if (identifier) params.set('identifier', identifier);
 
-        const res = await fetch(`${ENDPOINTS.connections.connectedAccountsSearch}?${params.toString()}`, {
+        const providerTypeMap: Record<string, string> = { DEFAULT: '0', CUSTOM: '1', ALL: '2' };
+        if (providerType) params.set('filter.provider_type', providerTypeMap[providerType] ?? '2');
+
+        const res = await fetch(`${ENDPOINTS.providers.list}?${params.toString()}`, {
           headers: envHeaders(token, environmentDomain),
         });
 
@@ -189,19 +212,22 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
           throw new Error(`Failed to search connectors: ${res.statusText}`);
         }
 
-        const data = (await res.json()) as SearchConnectedAccountsResponse;
-        const accounts = data.connected_accounts ?? [];
-        const rows = formatConnectedAccounts(accounts);
+        const data = (await res.json()) as ListProvidersResponse;
+        const providers = data.providers ?? [];
+        const rows = formatProviders(providers);
+        const count = data.total_size ?? providers.length;
         const pagination = data.next_page_token
           ? `\n\nNext page token: ${data.next_page_token}`
           : '\n\nNo more pages.';
         const prev = data.prev_page_token ? `\nPrevious page token: ${data.prev_page_token}` : '';
 
+        const filterDesc = identifier ? ` for identifier "${identifier}"` : '';
+
         return {
           content: [
             {
               type: 'text',
-              text: `Search results for "${query}" — ${data.total_size ?? accounts.length} total\n\n${rows || '(no matching connectors found)'}${pagination}${prev}`,
+              text: `Connectors${filterDesc} (${providerType ?? 'ALL'}) — ${count} total\n\n${rows || '(no connectors found)'}${pagination}${prev}`,
             },
           ],
         };

--- a/src/tools/connections.ts
+++ b/src/tools/connections.ts
@@ -199,8 +199,7 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
         if (pageToken) params.set('page_token', pageToken);
         if (identifier) params.set('identifier', identifier);
 
-        const providerTypeMap: Record<string, string> = { DEFAULT: '0', CUSTOM: '1', ALL: '2' };
-        if (providerType) params.set('filter.provider_type', providerTypeMap[providerType] ?? '2');
+        if (providerType) params.set('filter.provider_type', providerType);
 
         const res = await fetch(`${ENDPOINTS.providers.list}?${params.toString()}`, {
           headers: envHeaders(token, environmentDomain),

--- a/src/tools/connections.ts
+++ b/src/tools/connections.ts
@@ -289,7 +289,7 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
     {
       environmentId: environmentIdSchema,
       query: z.string().min(1).optional().describe('Search keyword to match against connector name, identifier, description, or categories (e.g. "gmail", "slack", "hubspot").'),
-      connectorType: z.enum(['DEFAULT', 'CUSTOM', 'ALL']).optional().default('ALL').describe('Filter by connector type: DEFAULT (built-in), CUSTOM (user-created), or ALL.'),
+      connectorType: z.enum(['SCALEKIT', 'CUSTOM', 'ALL']).optional().default('ALL').describe('Filter by connector type: SCALEKIT (pre-built connectors provided and maintained by Scalekit, shared across all environments), CUSTOM (connectors created by environment users, scoped to a single environment and not shared between environments), or ALL (both types).'),
       pageSize: z.number().int().min(1).max(1000).optional().default(20),
       pageToken: z.string().optional().describe('Opaque token from a previous response to fetch the next page.'),
       includeSetupStatus: z.boolean().optional().default(false).describe('When true, also checks which connectors have been set up (have active connections) in the environment.'),
@@ -303,7 +303,7 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
           content: [
             {
               type: 'text' as const,
-              text: 'At least one search criterion is required: provide a query or set connectorType to DEFAULT or CUSTOM.',
+              text: 'At least one search criterion is required: provide a query or set connectorType to SCALEKIT or CUSTOM.',
             },
           ],
         };
@@ -319,7 +319,7 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
           page_size: String(isSearch ? 1000 : pageSize),
         });
         if (!isSearch && pageToken) params.set('page_token', pageToken);
-        if (connectorType) params.set('filter.provider_type', connectorType);
+        if (connectorType) params.set('filter.provider_type', connectorType === 'SCALEKIT' ? 'DEFAULT' : connectorType);
 
         const providersFetch = fetch(`${ENDPOINTS.providers.list}?${params.toString()}`, {
           headers: envHeaders(token, environmentDomain),

--- a/src/tools/connections.ts
+++ b/src/tools/connections.ts
@@ -12,6 +12,7 @@ import {
   EnableConnectionResponse,
   ListConnectedAccountsResponse,
   ListConnectionsResponse,
+  SearchConnectedAccountsResponse,
 } from '../types/index.js';
 import { connectionIdSchema, environmentIdSchema, organizationIdSchema } from '../validators/types.js';
 import { TOOLS } from './index.js';
@@ -57,6 +58,7 @@ function formatConnectedAccounts(accounts: ConnectedAccount[]): string {
 export function registerConnectionTools(server: McpServer){
   TOOLS.list_environment_connections.registeredTool = getEnvironmentConnectionsTool(server)
   TOOLS.list_connected_accounts.registeredTool = listConnectedAccountsTool(server);
+  TOOLS.search_connectors.registeredTool = searchConnectorsTool(server);
   TOOLS.create_connected_account_magic_link.registeredTool = createConnectedAccountMagicLinkTool(server);
   TOOLS.list_organization_connections.registeredTool = getOrganizationConnectionsTool(server);
   TOOLS.enable_environment_connection.registeredTool = enableConnectionTool(server);
@@ -145,6 +147,71 @@ function listConnectedAccountsTool(server: McpServer): RegisteredTool {
             {
               type: 'text',
               text: 'Failed to list connected accounts. Please try again later.',
+            },
+          ],
+        };
+      }
+    }
+  );
+}
+
+function searchConnectorsTool(server: McpServer): RegisteredTool {
+  return server.tool(
+    TOOLS.search_connectors.name,
+    TOOLS.search_connectors.description,
+    {
+      environmentId: environmentIdSchema,
+      query: z.string().min(3, 'Query must be at least 3 characters'),
+      connectionId: connectionIdSchema.optional().describe('Optional connection ID to narrow results to a specific connection.'),
+      pageSize: z.number().int().min(1).max(30).optional().default(20),
+      pageToken: z.string().optional().describe('Opaque token from a previous response to fetch the next page.'),
+    },
+    async ({ environmentId, query, connectionId, pageSize, pageToken }, context) => {
+      const authInfo = context.authInfo as AuthInfo;
+      const token = authInfo?.token;
+
+      try {
+        const environmentDomain = await getEnvironmentDomain(token, environmentId);
+        const params = new URLSearchParams({
+          query,
+          page_size: String(pageSize),
+        });
+        if (pageToken) params.set('page_token', pageToken);
+        if (connectionId) params.set('connection_id', connectionId);
+
+        const res = await fetch(`${ENDPOINTS.connections.connectedAccountsSearch}?${params.toString()}`, {
+          headers: envHeaders(token, environmentDomain),
+        });
+
+        if (!res.ok) {
+          const errorText = await res.text();
+          logger.error(`Failed to search connectors: ${res.status} ${errorText}`);
+          throw new Error(`Failed to search connectors: ${res.statusText}`);
+        }
+
+        const data = (await res.json()) as SearchConnectedAccountsResponse;
+        const accounts = data.connected_accounts ?? [];
+        const rows = formatConnectedAccounts(accounts);
+        const pagination = data.next_page_token
+          ? `\n\nNext page token: ${data.next_page_token}`
+          : '\n\nNo more pages.';
+        const prev = data.prev_page_token ? `\nPrevious page token: ${data.prev_page_token}` : '';
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Search results for "${query}" — ${data.total_size ?? accounts.length} total\n\n${rows || '(no matching connectors found)'}${pagination}${prev}`,
+            },
+          ],
+        };
+      } catch (error) {
+        logger.error('Failed to search connectors', error);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'Failed to search connectors. Please try again later.',
             },
           ],
         };

--- a/src/tools/connections.ts
+++ b/src/tools/connections.ts
@@ -221,7 +221,7 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
     TOOLS.search_connectors.description,
     {
       environmentId: environmentIdSchema,
-      query: z.string().optional().describe('Search keyword to match against connector name, identifier, description, or categories (e.g. "gmail", "slack", "hubspot").'),
+      query: z.string().min(1).describe('Search keyword to match against connector name, identifier, description, or categories (e.g. "gmail", "slack", "hubspot").'),
       identifier: z.string().optional().describe('Exact provider identifier for a precise lookup (e.g. "GOOGLE_WORKSPACE", "SLACK"). Use "query" for keyword search instead.'),
       providerType: z.enum(['DEFAULT', 'CUSTOM', 'ALL']).optional().default('ALL').describe('Filter by provider type: DEFAULT (built-in), CUSTOM (environment-scoped), or ALL.'),
       pageSize: z.number().int().min(1).max(1000).optional().default(20),

--- a/src/tools/connections.ts
+++ b/src/tools/connections.ts
@@ -176,29 +176,42 @@ function formatProviders(providers: Provider[]): string {
     .join('\n');
 }
 
+function matchesQuery(provider: Provider, query: string): boolean {
+  const q = query.toLowerCase();
+  if (provider.display_name?.toLowerCase().includes(q)) return true;
+  if (provider.identifier?.toLowerCase().includes(q)) return true;
+  if (provider.description?.toLowerCase().includes(q)) return true;
+  if (provider.categories?.some((c) => c.toLowerCase().includes(q))) return true;
+  return false;
+}
+
 function searchConnectorsTool(server: McpServer): RegisteredTool {
   return server.tool(
     TOOLS.search_connectors.name,
     TOOLS.search_connectors.description,
     {
       environmentId: environmentIdSchema,
-      identifier: z.string().optional().describe('Exact provider identifier to look up (e.g. "google_workspace", "slack").'),
+      query: z.string().optional().describe('Search keyword to match against connector name, identifier, description, or categories (e.g. "gmail", "slack", "hubspot").'),
+      identifier: z.string().optional().describe('Exact provider identifier for a precise lookup (e.g. "GOOGLE_WORKSPACE", "SLACK"). Use "query" for keyword search instead.'),
       providerType: z.enum(['DEFAULT', 'CUSTOM', 'ALL']).optional().default('ALL').describe('Filter by provider type: DEFAULT (built-in), CUSTOM (environment-scoped), or ALL.'),
-      pageSize: z.number().int().min(1).max(30).optional().default(20),
+      pageSize: z.number().int().min(1).max(1000).optional().default(20),
       pageToken: z.string().optional().describe('Opaque token from a previous response to fetch the next page.'),
     },
-    async ({ environmentId, identifier, providerType, pageSize, pageToken }, context) => {
+    async ({ environmentId, query, identifier, providerType, pageSize, pageToken }, context) => {
       const authInfo = context.authInfo as AuthInfo;
       const token = authInfo?.token;
 
       try {
         const environmentDomain = await getEnvironmentDomain(token, environmentId);
-        const params = new URLSearchParams({
-          page_size: String(pageSize),
-        });
-        if (pageToken) params.set('page_token', pageToken);
-        if (identifier) params.set('identifier', identifier);
 
+        // When the user provides a search query, fetch all providers and filter client-side
+        // because the API's identifier param only supports exact match.
+        const isSearch = !!query && !identifier;
+        const params = new URLSearchParams({
+          page_size: String(isSearch ? 1000 : pageSize),
+        });
+        if (!isSearch && pageToken) params.set('page_token', pageToken);
+        if (identifier) params.set('identifier', identifier);
         if (providerType) params.set('filter.provider_type', providerType);
 
         const res = await fetch(`${ENDPOINTS.providers.list}?${params.toString()}`, {
@@ -212,21 +225,53 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
         }
 
         const data = (await res.json()) as ListProvidersResponse;
-        const providers = data.providers ?? [];
+        let providers = data.providers ?? [];
+
+        // Client-side search: filter, then paginate locally to bound context window size
+        if (isSearch) {
+          providers = providers.filter((p) => matchesQuery(p, query));
+          const totalMatches = providers.length;
+
+          let offset = 0;
+          if (pageToken?.startsWith('csearch_')) {
+            offset = parseInt(pageToken.slice(8), 10) || 0;
+          }
+          const page = providers.slice(offset, offset + pageSize);
+          const hasMore = offset + pageSize < totalMatches;
+
+          const rows = formatProviders(page);
+          const range = totalMatches > 0
+            ? ` (showing ${offset + 1}–${offset + page.length})`
+            : '';
+          const pagination = hasMore
+            ? `\n\nNext page token: csearch_${offset + pageSize}`
+            : '';
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Connectors matching "${query}" (${providerType ?? 'ALL'}) — ${totalMatches} found${range}\n\n${rows || '(no connectors found)'}${pagination}`,
+              },
+            ],
+          };
+        }
+
+        // Non-search paths (identifier exact match or list all): use API-native pagination
         const rows = formatProviders(providers);
         const count = data.total_size ?? providers.length;
         const pagination = data.next_page_token
           ? `\n\nNext page token: ${data.next_page_token}`
-          : '\n\nNo more pages.';
-        const prev = data.prev_page_token ? `\nPrevious page token: ${data.prev_page_token}` : '';
-
-        const filterDesc = identifier ? ` for identifier "${identifier}"` : '';
+          : '';
+        const filterDesc = identifier
+          ? ` for identifier "${identifier}"`
+          : '';
 
         return {
           content: [
             {
               type: 'text',
-              text: `Connectors${filterDesc} (${providerType ?? 'ALL'}) — ${count} total\n\n${rows || '(no connectors found)'}${pagination}${prev}`,
+              text: `Connectors${filterDesc} (${providerType ?? 'ALL'}) — ${count} found\n\n${rows || '(no connectors found)'}${pagination}`,
             },
           ],
         };

--- a/src/tools/connections.ts
+++ b/src/tools/connections.ts
@@ -222,22 +222,21 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
     {
       environmentId: environmentIdSchema,
       query: z.string().min(1).optional().describe('Search keyword to match against connector name, identifier, description, or categories (e.g. "gmail", "slack", "hubspot").'),
-      identifier: z.string().optional().describe('Exact provider identifier for a precise lookup (e.g. "GOOGLE_WORKSPACE", "SLACK"). Use "query" for keyword search instead.'),
-      providerType: z.enum(['DEFAULT', 'CUSTOM', 'ALL']).optional().default('ALL').describe('Filter by provider type: DEFAULT (built-in), CUSTOM (environment-scoped), or ALL.'),
+      connectorType: z.enum(['DEFAULT', 'CUSTOM', 'ALL']).optional().default('ALL').describe('Filter by connector type: DEFAULT (built-in), CUSTOM (user-created), or ALL.'),
       pageSize: z.number().int().min(1).max(1000).optional().default(20),
       pageToken: z.string().optional().describe('Opaque token from a previous response to fetch the next page.'),
       includeSetupStatus: z.boolean().optional().default(false).describe('When true, also checks which connectors have been set up (have active connections) in the environment.'),
     },
-    async ({ environmentId, query, identifier, providerType, pageSize, pageToken, includeSetupStatus }, context) => {
+    async ({ environmentId, query, connectorType, pageSize, pageToken, includeSetupStatus }, context) => {
       const authInfo = context.authInfo as AuthInfo;
       const token = authInfo?.token;
 
-      if (!query && !identifier && (!providerType || providerType === 'ALL')) {
+      if (!query && (!connectorType || connectorType === 'ALL')) {
         return {
           content: [
             {
               type: 'text' as const,
-              text: 'At least one search criterion is required: provide a query, identifier, or providerType (DEFAULT or CUSTOM).',
+              text: 'At least one search criterion is required: provide a query or set connectorType to DEFAULT or CUSTOM.',
             },
           ],
         };
@@ -246,15 +245,14 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
       try {
         const environmentDomain = await getEnvironmentDomain(token, environmentId);
 
-        // When the user provides a search query, fetch all providers and filter client-side
+        // Fetch all providers and filter client-side when a query is provided,
         // because the API's identifier param only supports exact match.
-        const isSearch = !!query && !identifier;
+        const isSearch = !!query;
         const params = new URLSearchParams({
           page_size: String(isSearch ? 1000 : pageSize),
         });
         if (!isSearch && pageToken) params.set('page_token', pageToken);
-        if (identifier) params.set('identifier', identifier);
-        if (providerType) params.set('filter.provider_type', providerType);
+        if (connectorType) params.set('filter.provider_type', connectorType);
 
         const providersFetch = fetch(`${ENDPOINTS.providers.list}?${params.toString()}`, {
           headers: envHeaders(token, environmentDomain),
@@ -300,27 +298,24 @@ function searchConnectorsTool(server: McpServer): RegisteredTool {
             content: [
               {
                 type: 'text',
-                text: `Connectors matching "${query}" (${providerType ?? 'ALL'}) — ${totalMatches} found${range}\n\n${rows || '(no connectors found)'}${pagination}`,
+                text: `Connectors matching "${query}" (${connectorType ?? 'ALL'}) — ${totalMatches} found${range}\n\n${rows || '(no connectors found)'}${pagination}`,
               },
             ],
           };
         }
 
-        // Non-search paths (identifier exact match or list all): use API-native pagination
+        // Non-search path (connectorType filter only): use API-native pagination
         const rows = formatProviders(providers, setupMap);
         const count = data.total_size ?? providers.length;
         const pagination = data.next_page_token
           ? `\n\nNext page token: ${data.next_page_token}`
-          : '';
-        const filterDesc = identifier
-          ? ` for identifier "${identifier}"`
           : '';
 
         return {
           content: [
             {
               type: 'text',
-              text: `Connectors${filterDesc} (${providerType ?? 'ALL'}) — ${count} found\n\n${rows || '(no connectors found)'}${pagination}`,
+              text: `Connectors (${connectorType ?? 'ALL'}) — ${count} found\n\n${rows || '(no connectors found)'}${pagination}`,
             },
           ],
         };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -140,13 +140,13 @@ const toolsList = {
   search_connectors: {
     name: 'search_connectors',
     description:
-      'Search available connectors (providers such as Google, Notion, Slack) in the specified environment. Requires environmentId (format: env_<number>). Use "query" for keyword search (e.g. "gmail", "hubspot") or "identifier" for exact lookup (e.g. "GOOGLE_WORKSPACE"). Optionally filter by providerType (DEFAULT, CUSTOM, or ALL). Set includeSetupStatus=true to see which connectors have been set up (have active connections) in the environment. Show the response in tabular structured manner.',
+      'Search the connector catalog (e.g. Google, Notion, Slack) for the given environment. Returns matching connectors with their identifier, category, and type. When includeSetupStatus is true, each result is annotated with whether the connector has been set up in the environment.',
     scopes: [SCOPES.environmentRead],
   },
   search_tools: {
     name: 'search_tools',
     description:
-      'Search available tools (actions) for connectors in the specified environment. Requires environmentId (format: env_<number>). Filter by provider (e.g. "GOOGLE"), query text (min 3 chars), identifier (connected account identifier), connector name, connectedAccountId (e.g. "ca_123"), or specific toolNames. Set summary=true for tool names only. Supports pagination via pageSize and pageToken.',
+      'Search available tools (actions) exposed by connectors in the given environment. Returns tool definitions with provider, tags, and metadata. Use summary=true to retrieve tool names only. At least one filter criterion is required.',
     scopes: [SCOPES.environmentRead],
   },
   search_docs: {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -82,7 +82,7 @@ const toolsList = {
   list_connected_accounts: {
     name: 'list_connected_accounts',
     description:
-      'List connected accounts (OAuth connector accounts such as Gmail, Notion) at the environment level. Requires environmentId (format: env_<number>). Supports pagination: pageSize (default 20) and optional pageToken from the previous response. Show the response in tabular structured manner. After each page, ask whether to fetch the next page.',
+      'List users (connected accounts) who have authorized with connectors in the given environment. Filter by connector type (e.g. "HUBSPOT") or specific connection ID. Returns accounts grouped by connector showing identifier, status, and auth details.',
     scopes: [SCOPES.environmentRead],
   },
   create_connected_account_magic_link: {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -140,7 +140,7 @@ const toolsList = {
   search_connectors: {
     name: 'search_connectors',
     description:
-      'List and search available connectors (providers such as Google, Notion, Slack) in the specified environment. Requires environmentId (format: env_<number>). Optionally filter by exact provider identifier or provider type (DEFAULT for built-in, CUSTOM for environment-scoped, ALL for both). Supports pagination via pageSize and pageToken. Show the response in tabular structured manner.',
+      'Search available connectors (providers such as Google, Notion, Slack) in the specified environment. Requires environmentId (format: env_<number>). Use "query" for keyword search (e.g. "gmail", "hubspot") or "identifier" for exact lookup (e.g. "GOOGLE_WORKSPACE"). Optionally filter by providerType (DEFAULT, CUSTOM, or ALL). Show the response in tabular structured manner.',
     scopes: [SCOPES.environmentRead],
   },
   search_tools: {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -146,7 +146,7 @@ const toolsList = {
   search_tools: {
     name: 'search_tools',
     description:
-      'Search available tools (actions) exposed by connectors in the given environment. Filter by connector name (e.g. "HUBSPOT"), text query, or specific tool names. Returns tool definitions with provider, tags, and metadata. Use summary=true to retrieve tool names only.',
+      'Search available tools (actions) exposed by connectors in the given environment. Filter by connector name (e.g. "HUBSPOT") or search by action (e.g. "search contacts"). Returns tools grouped by connector. Set summary=false for full tool definitions including input schemas. Output schemas are not available — refer to the connector\'s official API documentation for response structures.',
     scopes: [SCOPES.environmentRead],
   },
   search_docs: {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -146,7 +146,7 @@ const toolsList = {
   search_tools: {
     name: 'search_tools',
     description:
-      'Search available tools (actions) exposed by connectors in the given environment. Returns tool definitions with provider, tags, and metadata. Use summary=true to retrieve tool names only. At least one filter criterion is required.',
+      'Search available tools (actions) exposed by connectors in the given environment. Filter by connector name (e.g. "HUBSPOT"), text query, or specific tool names. Returns tool definitions with provider, tags, and metadata. Use summary=true to retrieve tool names only.',
     scopes: [SCOPES.environmentRead],
   },
   search_docs: {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,6 +5,7 @@ import { registerDocsTools } from './docs.js';
 import { registerEnvironmentTools } from './environments.js';
 import { registerOrganizationTools } from './organizations.js';
 import { registerResourceTools } from './resource.js';
+import { registerToolSearchTools } from './tool-search.js';
 import { registerWorkspaceTools } from './workspace.js';
 
 const toolsList = {
@@ -136,6 +137,18 @@ const toolsList = {
     description: 'Switch the authentication of an existing MCP server to Scalekit authentication. Requires environmentId parameter (format: env_<number>). It needs the following parameters: id (id of the MCP server). The tool will update the MCP server to use Scalekit authentication solution.',
     scopes: [SCOPES.environmentWrite],
   },
+  search_connectors: {
+    name: 'search_connectors',
+    description:
+      'Search OAuth connectors (connected accounts like Google, Notion, Slack) in the specified environment. Requires environmentId (format: env_<number>) and a query string (minimum 3 characters) that matches against identifiers, providers, or connector names. Optionally filter by connectionId. Supports pagination via pageSize and pageToken. Show the response in tabular structured manner.',
+    scopes: [SCOPES.environmentRead],
+  },
+  search_tools: {
+    name: 'search_tools',
+    description:
+      'Search available tools (actions) for connectors in the specified environment. Requires environmentId (format: env_<number>). Two modes: (1) Broad search — provide a query string (min 3 chars) and/or provider name (e.g. "GOOGLE") to search across all tools. (2) Identifier-scoped — provide an identifier (the unique connected account identifier string) to list all tools available for that specific account. Optionally filter by toolNames array or set summary=true for tool names only. Supports pagination via pageSize and pageToken.',
+    scopes: [SCOPES.environmentRead],
+  },
   search_docs: {
     name: 'search_docs',
     description: 'Search Scalekit documentation by keyword. Prefer reading docs:// resources directly — use this tool only when no specific docs:// resource clearly covers the topic.',
@@ -200,5 +213,6 @@ export function registerTools(server: McpServer) {
     registerWorkspaceTools(server);
     registerConnectionTools(server);
     registerResourceTools(server);
+    registerToolSearchTools(server);
     registerDocsTools(server);
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -146,7 +146,7 @@ const toolsList = {
   search_tools: {
     name: 'search_tools',
     description:
-      'Search available tools (actions) for connectors in the specified environment. Requires environmentId (format: env_<number>). Two modes: (1) Broad search — provide a query string (min 3 chars) and/or provider name (e.g. "GOOGLE") to search across all tools. (2) Identifier-scoped — provide an identifier (the unique connected account identifier string) to list all tools available for that specific account. Optionally filter by toolNames array or set summary=true for tool names only. Supports pagination via pageSize and pageToken.',
+      'Search available tools (actions) for connectors in the specified environment. Requires environmentId (format: env_<number>). Filter by provider (e.g. "GOOGLE"), query text (min 3 chars), identifier (connected account identifier), connector name, connectedAccountId (e.g. "ca_123"), or specific toolNames. Set summary=true for tool names only. Supports pagination via pageSize and pageToken.',
     scopes: [SCOPES.environmentRead],
   },
   search_docs: {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -140,7 +140,7 @@ const toolsList = {
   search_connectors: {
     name: 'search_connectors',
     description:
-      'Search OAuth connectors (connected accounts like Google, Notion, Slack) in the specified environment. Requires environmentId (format: env_<number>) and a query string (minimum 3 characters) that matches against identifiers, providers, or connector names. Optionally filter by connectionId. Supports pagination via pageSize and pageToken. Show the response in tabular structured manner.',
+      'List and search available connectors (providers such as Google, Notion, Slack) in the specified environment. Requires environmentId (format: env_<number>). Optionally filter by exact provider identifier or provider type (DEFAULT for built-in, CUSTOM for environment-scoped, ALL for both). Supports pagination via pageSize and pageToken. Show the response in tabular structured manner.',
     scopes: [SCOPES.environmentRead],
   },
   search_tools: {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -140,7 +140,7 @@ const toolsList = {
   search_connectors: {
     name: 'search_connectors',
     description:
-      'Search available connectors (providers such as Google, Notion, Slack) in the specified environment. Requires environmentId (format: env_<number>). Use "query" for keyword search (e.g. "gmail", "hubspot") or "identifier" for exact lookup (e.g. "GOOGLE_WORKSPACE"). Optionally filter by providerType (DEFAULT, CUSTOM, or ALL). Show the response in tabular structured manner.',
+      'Search available connectors (providers such as Google, Notion, Slack) in the specified environment. Requires environmentId (format: env_<number>). Use "query" for keyword search (e.g. "gmail", "hubspot") or "identifier" for exact lookup (e.g. "GOOGLE_WORKSPACE"). Optionally filter by providerType (DEFAULT, CUSTOM, or ALL). Set includeSetupStatus=true to see which connectors have been set up (have active connections) in the environment. Show the response in tabular structured manner.',
     scopes: [SCOPES.environmentRead],
   },
   search_tools: {

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -62,9 +62,9 @@ function searchToolsTool(server: McpServer): RegisteredTool {
       summary: z
         .boolean()
         .optional()
-        .default(false)
+        .default(true)
         .describe(
-          'If true, return only tool names instead of full tool details.'
+          'When true (default), returns tool names only. Set to false to get full tool definitions including input schemas.'
         ),
       pageSize: z.number().int().min(1).max(30).optional().default(20),
       pageToken: z

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -34,7 +34,7 @@ function formatToolsSummary(tools: ScalekitTool[]): string {
 
 /** Full format: complete tool definitions with input schemas. */
 function formatToolsFull(tools: ScalekitTool[]): string {
-  return tools
+  const rows = tools
     .map((tool) => {
       const details = [
         `id: ${tool.id}`,
@@ -49,6 +49,7 @@ function formatToolsFull(tools: ScalekitTool[]): string {
       return `- ${details}`;
     })
     .join('\n');
+  return rows + '\n\nNote: Output schemas are not included in tool definitions. For response structures, refer to the connector\'s official API documentation (see rest_api_info.base_url and rest_api_info.path_template for the upstream endpoint).';
 }
 
 export function registerToolSearchTools(server: McpServer) {

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -83,6 +83,17 @@ function searchToolsTool(server: McpServer): RegisteredTool {
       { environmentId, query, provider, identifier, toolNames, summary, pageSize, pageToken },
       context
     ) => {
+      if (!query && !provider && !identifier && !toolNames?.length) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'At least one search criterion is required: provide a query, provider, identifier, or toolNames.',
+            },
+          ],
+        };
+      }
+
       const authInfo = context.authInfo as AuthInfo;
       const token = authInfo?.token;
 

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -1,0 +1,239 @@
+import { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import fetch from 'node-fetch';
+import { z } from 'zod';
+import { envHeaders, getEnvironmentDomain } from '../lib/api.js';
+import { logger } from '../lib/logger.js';
+import { ENDPOINTS } from '../types/endpoints.js';
+import {
+  AuthInfo,
+  ListAvailableToolsResponse,
+  ListToolsResponse,
+  ScalekitTool,
+} from '../types/index.js';
+import { environmentIdSchema } from '../validators/types.js';
+import { TOOLS } from './index.js';
+
+function formatTools(tools: ScalekitTool[]): string {
+  return tools
+    .map((tool) => {
+      const details = [
+        `id: ${tool.id}`,
+        `provider: ${tool.provider}`,
+        tool.tags?.length ? `tags: ${tool.tags.join(', ')}` : null,
+        tool.is_default != null ? `is_default: ${tool.is_default}` : null,
+        tool.updated_at ? `updated_at: ${tool.updated_at}` : null,
+        tool.definition
+          ? `definition: ${JSON.stringify(tool.definition)}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(' | ');
+      return `- ${details}`;
+    })
+    .join('\n');
+}
+
+function formatToolNames(names: string[]): string {
+  return names.map((name) => `- ${name}`).join('\n');
+}
+
+export function registerToolSearchTools(server: McpServer) {
+  TOOLS.search_tools.registeredTool = searchToolsTool(server);
+}
+
+function searchToolsTool(server: McpServer): RegisteredTool {
+  return server.tool(
+    TOOLS.search_tools.name,
+    TOOLS.search_tools.description,
+    {
+      environmentId: environmentIdSchema,
+      query: z
+        .string()
+        .min(3, 'Query must be at least 3 characters')
+        .optional()
+        .describe('Text search across tool names and descriptions.'),
+      provider: z
+        .string()
+        .optional()
+        .describe('Filter by provider name (e.g. "GOOGLE", "NOTION").'),
+      identifier: z
+        .string()
+        .optional()
+        .describe(
+          'Connected account identifier string. When provided, switches to identifier-scoped mode and lists all tools available for that account.'
+        ),
+      toolNames: z
+        .array(z.string())
+        .optional()
+        .describe('Filter by specific tool names.'),
+      summary: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          'If true, return only tool names instead of full tool details.'
+        ),
+      pageSize: z.number().int().min(1).max(30).optional().default(20),
+      pageToken: z
+        .string()
+        .optional()
+        .describe('Opaque token from a previous response to fetch the next page.'),
+    },
+    async (
+      { environmentId, query, provider, identifier, toolNames, summary, pageSize, pageToken },
+      context
+    ) => {
+      const authInfo = context.authInfo as AuthInfo;
+      const token = authInfo?.token;
+
+      try {
+        const environmentDomain = await getEnvironmentDomain(
+          token,
+          environmentId
+        );
+
+        if (identifier) {
+          return await listAvailableToolsMode(
+            token,
+            environmentDomain,
+            identifier,
+            pageSize,
+            pageToken
+          );
+        }
+
+        return await listToolsMode(
+          token,
+          environmentDomain,
+          { query, provider, toolNames, summary },
+          pageSize,
+          pageToken
+        );
+      } catch (error) {
+        logger.error('Failed to search tools', error);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'Failed to search tools. Please try again later.',
+            },
+          ],
+        };
+      }
+    }
+  );
+}
+
+async function listToolsMode(
+  token: string,
+  environmentDomain: string,
+  filters: {
+    query?: string;
+    provider?: string;
+    toolNames?: string[];
+    summary?: boolean;
+  },
+  pageSize: number,
+  pageToken?: string
+) {
+  const params = new URLSearchParams({
+    page_size: String(pageSize),
+  });
+  if (pageToken) params.set('page_token', pageToken);
+  if (filters.query) params.set('filter.query', filters.query);
+  if (filters.provider) params.set('filter.provider', filters.provider);
+  if (filters.summary) params.set('filter.summary', 'true');
+  if (filters.toolNames?.length) {
+    for (const name of filters.toolNames) {
+      params.append('filter.tool_name', name);
+    }
+  }
+
+  const res = await fetch(
+    `${ENDPOINTS.tools.list}?${params.toString()}`,
+    { headers: envHeaders(token, environmentDomain) }
+  );
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    logger.error(`Failed to search tools: ${res.status} ${errorText}`);
+    throw new Error(`Failed to search tools: ${res.statusText}`);
+  }
+
+  const data = (await res.json()) as ListToolsResponse;
+
+  const isSummary = filters.summary && data.tool_names?.length;
+  const body = isSummary
+    ? formatToolNames(data.tool_names)
+    : formatTools(data.tools ?? []);
+  const count = data.total_size ?? (isSummary ? data.tool_names?.length : data.tools?.length) ?? 0;
+  const pagination = data.next_page_token
+    ? `\n\nNext page token: ${data.next_page_token}`
+    : '\n\nNo more pages.';
+  const prev = data.prev_page_token
+    ? `\nPrevious page token: ${data.prev_page_token}`
+    : '';
+
+  const searchDesc = [
+    filters.query ? `query="${filters.query}"` : null,
+    filters.provider ? `provider=${filters.provider}` : null,
+  ]
+    .filter(Boolean)
+    .join(', ');
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: `Tools${searchDesc ? ` matching ${searchDesc}` : ''} — ${count} total\n\n${body || '(no tools found)'}${pagination}${prev}`,
+      },
+    ],
+  };
+}
+
+async function listAvailableToolsMode(
+  token: string,
+  environmentDomain: string,
+  identifier: string,
+  pageSize: number,
+  pageToken?: string
+) {
+  const params = new URLSearchParams({
+    identifier,
+    page_size: String(pageSize),
+  });
+  if (pageToken) params.set('page_token', pageToken);
+
+  const res = await fetch(
+    `${ENDPOINTS.tools.listAvailable}?${params.toString()}`,
+    { headers: envHeaders(token, environmentDomain) }
+  );
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    logger.error(
+      `Failed to list available tools: ${res.status} ${errorText}`
+    );
+    throw new Error(`Failed to list available tools: ${res.statusText}`);
+  }
+
+  const data = (await res.json()) as ListAvailableToolsResponse;
+  const tools = data.tools ?? [];
+  const body = formatTools(tools);
+  const count = data.total_size ?? tools.length;
+  const pagination = data.next_page_token
+    ? `\n\nNext page token: ${data.next_page_token}`
+    : '\n\nNo more pages.';
+  const prev = data.prev_page_token
+    ? `\nPrevious page token: ${data.prev_page_token}`
+    : '';
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: `Available tools for identifier "${identifier}" — ${count} total\n\n${body || '(no tools found)'}${pagination}${prev}`,
+      },
+    ],
+  };
+}

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -12,6 +12,23 @@ import {
 import { environmentIdSchema } from '../validators/types.js';
 import { TOOLS } from './index.js';
 
+/** Extracts the email claim from a JWT access token (already validated by middleware). */
+function getEmailFromToken(token: string): string | undefined {
+  try {
+    const payload = token.split('.')[1];
+    if (!payload) return undefined;
+    const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString());
+    return decoded.email ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Returns true when the connector identifier looks environment-scoped (custom). */
+function isCustomConnector(connector: string): boolean {
+  return connector.includes(':');
+}
+
 /** Summary format: group tools by connector, show name + short description. */
 function formatToolsSummary(tools: ScalekitTool[]): string {
   const grouped = new Map<string, ScalekitTool[]>();
@@ -133,7 +150,7 @@ function searchToolsTool(server: McpServer): RegisteredTool {
 async function fetchTools(
   token: string,
   environmentDomain: string,
-  apiFilters: { provider?: string; query?: string },
+  apiFilters: { provider?: string; query?: string; connector?: string; identifier?: string },
   pageSize: number,
   pageToken?: string
 ): Promise<ListToolsResponse> {
@@ -141,6 +158,8 @@ async function fetchTools(
   if (pageToken) params.set('page_token', pageToken);
   if (apiFilters.provider) params.set('filter.provider', apiFilters.provider);
   if (apiFilters.query) params.set('filter.query', apiFilters.query);
+  if (apiFilters.connector) params.set('filter.connector', apiFilters.connector);
+  if (apiFilters.identifier) params.set('filter.identifier', apiFilters.identifier);
 
   const res = await fetch(
     `${ENDPOINTS.tools.list}?${params.toString()}`,
@@ -172,8 +191,14 @@ async function listToolsMode(
   let tools: ScalekitTool[];
   let clientFiltered = false;
 
-  if (connector) {
-    // Try exact match first
+  if (connector && isCustomConnector(connector)) {
+    // Custom connector: use filter.connector + filter.identifier so the backend
+    // resolves the connected account and includes custom MCP tools.
+    const email = getEmailFromToken(token);
+    data = await fetchTools(token, environmentDomain, { connector, identifier: email, query: filters.query }, pageSize, pageToken);
+    tools = data.tools ?? [];
+  } else if (connector) {
+    // Standard connector: filter by provider
     data = await fetchTools(token, environmentDomain, { provider: connector, query: filters.query }, pageSize, pageToken);
     tools = data.tools ?? [];
 

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -145,7 +145,7 @@ async function listToolsMode(
     page_size: String(pageSize),
   });
   if (pageToken) params.set('page_token', pageToken);
-  if (filters.connector) params.set('filter.provider', filters.connector);
+  if (filters.connector) params.set('filter.provider', filters.connector.toUpperCase());
   if (filters.query) params.set('filter.query', filters.query);
 
   const res = await fetch(

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -184,6 +184,14 @@ async function listToolsMode(
     // resolves the connected account and includes custom MCP tools.
     data = await fetchTools(token, environmentDomain, { connector, identifier: filters.identifier, query: filters.query }, pageSize, pageToken);
     tools = data.tools ?? [];
+    if (tools.length === 0) {
+      return {
+        content: [{
+          type: 'text' as const,
+          text: `No tools found for connection "${filters.connector}" with identifier "${filters.identifier}". This usually means either: (1) a custom connection has not been created for this connector in the environment, or (2) a connected account has not been set up for this identifier. Verify both in the Scalekit dashboard before retrying.`,
+        }],
+      };
+    }
   } else if (connector) {
     // Standard connector: filter by provider
     data = await fetchTools(token, environmentDomain, { provider: connector, query: filters.query }, pageSize, pageToken);

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -12,11 +12,6 @@ import {
 import { environmentIdSchema } from '../validators/types.js';
 import { TOOLS } from './index.js';
 
-/** Returns true when the connector identifier looks environment-scoped (custom). */
-function isCustomConnector(connector: string): boolean {
-  return connector.includes(':');
-}
-
 /** Summary format: group tools by connector, show name + short description. */
 function formatToolsSummary(tools: ScalekitTool[]): string {
   const grouped = new Map<string, ScalekitTool[]>();
@@ -184,17 +179,9 @@ async function listToolsMode(
   let tools: ScalekitTool[];
   let clientFiltered = false;
 
-  if (connector && isCustomConnector(connector)) {
-    // Custom connector: use filter.connector + filter.identifier so the backend
+  if (connector && filters.identifier) {
+    // Identifier provided: use filter.connector + filter.identifier so the backend
     // resolves the connected account and includes custom MCP tools.
-    if (!filters.identifier) {
-      return {
-        content: [{
-          type: 'text' as const,
-          text: 'An identifier is required when searching tools for a custom connector. Provide the connected account identifier (e.g. user ID, email, or app-specific key used when the connected account was created).',
-        }],
-      };
-    }
     data = await fetchTools(token, environmentDomain, { connector, identifier: filters.identifier, query: filters.query }, pageSize, pageToken);
     tools = data.tools ?? [];
   } else if (connector) {

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -46,33 +46,15 @@ function searchToolsTool(server: McpServer): RegisteredTool {
     TOOLS.search_tools.description,
     {
       environmentId: environmentIdSchema,
+      connector: z
+        .string()
+        .optional()
+        .describe('Filter by connector (e.g. "GOOGLE", "HUBSPOT", "NOTION").'),
       query: z
         .string()
         .min(3, 'Query must be at least 3 characters')
         .optional()
         .describe('Text search across tool names and descriptions.'),
-      provider: z
-        .string()
-        .optional()
-        .describe('Filter by provider name (e.g. "GOOGLE", "NOTION").'),
-      identifier: z
-        .string()
-        .optional()
-        .describe(
-          'Filter by connected account identifier (e.g. "app_google_workspace").'
-        ),
-      connector: z
-        .string()
-        .optional()
-        .describe(
-          'Connector name (e.g. "My Gmail"). When set with identifier, resolves to a specific connected account and includes its custom MCP tools.'
-        ),
-      connectedAccountId: z
-        .string()
-        .optional()
-        .describe(
-          'Connected account ID (e.g. "ca_123"). Alternative to identifier + connector for directly identifying the connected account.'
-        ),
       toolNames: z
         .array(z.string())
         .optional()
@@ -91,15 +73,15 @@ function searchToolsTool(server: McpServer): RegisteredTool {
         .describe('Opaque token from a previous response to fetch the next page.'),
     },
     async (
-      { environmentId, query, provider, identifier, connector, connectedAccountId, toolNames, summary, pageSize, pageToken },
+      { environmentId, connector, query, toolNames, summary, pageSize, pageToken },
       context
     ) => {
-      if (!query && !provider && !identifier && !connector && !connectedAccountId && !toolNames?.length) {
+      if (!connector && !query && !toolNames?.length) {
         return {
           content: [
             {
               type: 'text' as const,
-              text: 'At least one search criterion is required: provide a query, provider, identifier, connector, connectedAccountId, or toolNames.',
+              text: 'At least one search criterion is required: provide a connector, query, or toolNames.',
             },
           ],
         };
@@ -117,7 +99,7 @@ function searchToolsTool(server: McpServer): RegisteredTool {
         return await listToolsMode(
           token,
           environmentDomain,
-          { query, provider, identifier, connector, connectedAccountId, toolNames, summary },
+          { connector, query, toolNames, summary },
           pageSize,
           pageToken
         );
@@ -140,11 +122,8 @@ async function listToolsMode(
   token: string,
   environmentDomain: string,
   filters: {
-    query?: string;
-    provider?: string;
-    identifier?: string;
     connector?: string;
-    connectedAccountId?: string;
+    query?: string;
     toolNames?: string[];
     summary?: boolean;
   },
@@ -155,11 +134,8 @@ async function listToolsMode(
     page_size: String(pageSize),
   });
   if (pageToken) params.set('page_token', pageToken);
+  if (filters.connector) params.set('filter.provider', filters.connector);
   if (filters.query) params.set('filter.query', filters.query);
-  if (filters.provider) params.set('filter.provider', filters.provider);
-  if (filters.identifier) params.set('filter.identifier', filters.identifier);
-  if (filters.connector) params.set('filter.connector', filters.connector);
-  if (filters.connectedAccountId) params.set('filter.connected_account_id', filters.connectedAccountId);
   if (filters.summary) params.set('filter.summary', 'true');
   if (filters.toolNames?.length) {
     for (const name of filters.toolNames) {
@@ -193,11 +169,8 @@ async function listToolsMode(
     : '';
 
   const searchDesc = [
-    filters.query ? `query="${filters.query}"` : null,
-    filters.provider ? `provider=${filters.provider}` : null,
-    filters.identifier ? `identifier=${filters.identifier}` : null,
     filters.connector ? `connector=${filters.connector}` : null,
-    filters.connectedAccountId ? `connected_account_id=${filters.connectedAccountId}` : null,
+    filters.query ? `query="${filters.query}"` : null,
   ]
     .filter(Boolean)
     .join(', ');

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -12,15 +12,34 @@ import {
 import { environmentIdSchema } from '../validators/types.js';
 import { TOOLS } from './index.js';
 
-function formatTools(tools: ScalekitTool[]): string {
+/** Summary format: group tools by connector, show name + short description. */
+function formatToolsSummary(tools: ScalekitTool[]): string {
+  const grouped = new Map<string, ScalekitTool[]>();
+  for (const tool of tools) {
+    const key = tool.provider || 'UNKNOWN';
+    const list = grouped.get(key) ?? [];
+    list.push(tool);
+    grouped.set(key, list);
+  }
+  const sections: string[] = [];
+  for (const [connector, connectorTools] of grouped) {
+    const lines = connectorTools.map((t) => {
+      const desc = t.definition?.description || t.definition?.display_name || '';
+      return desc ? `  - ${t.definition?.name ?? t.id} — ${desc}` : `  - ${t.definition?.name ?? t.id}`;
+    });
+    sections.push(`${connector} (${connectorTools.length} tool${connectorTools.length === 1 ? '' : 's'}):\n${lines.join('\n')}`);
+  }
+  return sections.join('\n\n');
+}
+
+/** Full format: complete tool definitions with input schemas. */
+function formatToolsFull(tools: ScalekitTool[]): string {
   return tools
     .map((tool) => {
       const details = [
         `id: ${tool.id}`,
-        `provider: ${tool.provider}`,
+        `connector: ${tool.provider}`,
         tool.tags?.length ? `tags: ${tool.tags.join(', ')}` : null,
-        tool.is_default != null ? `is_default: ${tool.is_default}` : null,
-        tool.updated_at ? `updated_at: ${tool.updated_at}` : null,
         tool.definition
           ? `definition: ${JSON.stringify(tool.definition)}`
           : null,
@@ -30,10 +49,6 @@ function formatTools(tools: ScalekitTool[]): string {
       return `- ${details}`;
     })
     .join('\n');
-}
-
-function formatToolNames(names: string[]): string {
-  return names.map((name) => `- ${name}`).join('\n');
 }
 
 export function registerToolSearchTools(server: McpServer) {
@@ -54,17 +69,13 @@ function searchToolsTool(server: McpServer): RegisteredTool {
         .string()
         .min(3, 'Query must be at least 3 characters')
         .optional()
-        .describe('Text search across tool names and descriptions.'),
-      toolNames: z
-        .array(z.string())
-        .optional()
-        .describe('Filter by specific tool names.'),
+        .describe('Search by action or capability (e.g. "search contacts", "send email", "create deal").'),
       summary: z
         .boolean()
         .optional()
         .default(true)
         .describe(
-          'When true (default), returns tool names only. Set to false to get full tool definitions including input schemas.'
+          'When true (default), returns tools grouped by connector with name and description. Set to false for full tool definitions including input schemas.'
         ),
       pageSize: z.number().int().min(1).max(30).optional().default(20),
       pageToken: z
@@ -73,15 +84,15 @@ function searchToolsTool(server: McpServer): RegisteredTool {
         .describe('Opaque token from a previous response to fetch the next page.'),
     },
     async (
-      { environmentId, connector, query, toolNames, summary, pageSize, pageToken },
+      { environmentId, connector, query, summary, pageSize, pageToken },
       context
     ) => {
-      if (!connector && !query && !toolNames?.length) {
+      if (!connector && !query) {
         return {
           content: [
             {
               type: 'text' as const,
-              text: 'At least one search criterion is required: provide a connector, query, or toolNames.',
+              text: 'At least one search criterion is required: provide a connector or query.',
             },
           ],
         };
@@ -99,7 +110,7 @@ function searchToolsTool(server: McpServer): RegisteredTool {
         return await listToolsMode(
           token,
           environmentDomain,
-          { connector, query, toolNames, summary },
+          { connector, query, summary },
           pageSize,
           pageToken
         );
@@ -124,7 +135,6 @@ async function listToolsMode(
   filters: {
     connector?: string;
     query?: string;
-    toolNames?: string[];
     summary?: boolean;
   },
   pageSize: number,
@@ -136,12 +146,6 @@ async function listToolsMode(
   if (pageToken) params.set('page_token', pageToken);
   if (filters.connector) params.set('filter.provider', filters.connector);
   if (filters.query) params.set('filter.query', filters.query);
-  if (filters.summary) params.set('filter.summary', 'true');
-  if (filters.toolNames?.length) {
-    for (const name of filters.toolNames) {
-      params.append('filter.tool_name', name);
-    }
-  }
 
   const res = await fetch(
     `${ENDPOINTS.tools.list}?${params.toString()}`,
@@ -155,15 +159,16 @@ async function listToolsMode(
   }
 
   const data = (await res.json()) as ListToolsResponse;
+  const tools = data.tools ?? [];
+  const count = data.total_size ?? tools.length;
 
-  const isSummary = filters.summary && data.tool_names?.length;
-  const body = isSummary
-    ? formatToolNames(data.tool_names)
-    : formatTools(data.tools ?? []);
-  const count = data.total_size ?? (isSummary ? data.tool_names?.length : data.tools?.length) ?? 0;
+  const body = filters.summary
+    ? formatToolsSummary(tools)
+    : formatToolsFull(tools);
+
   const pagination = data.next_page_token
     ? `\n\nNext page token: ${data.next_page_token}`
-    : '\n\nNo more pages.';
+    : '';
   const prev = data.prev_page_token
     ? `\nPrevious page token: ${data.prev_page_token}`
     : '';

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -65,7 +65,7 @@ function searchToolsTool(server: McpServer): RegisteredTool {
       connector: z
         .string()
         .optional()
-        .describe('Filter by connector identifier as returned by search_connectors (e.g. "GMAIL", "HUBSPOT", "NOTION", "SLACK").'),
+        .describe('For standard connectors, the connector identifier as returned by search_connectors (e.g. "GMAIL", "HUBSPOT", "NOTION", "SLACK"). For custom connectors, the connection name (e.g. "My Sentry", "Bitly Production").'),
       identifier: z
         .string()
         .optional()
@@ -222,11 +222,17 @@ async function listToolsMode(
     .filter(Boolean)
     .join(', ');
 
+  // When searching by query alone, hint that custom connector tools require
+  // connector + identifier to be found.
+  const customToolHint = !filters.identifier
+    ? '\n\nNote: This search only covers standard connector tools. To search tools from custom connectors, also provide the connection name (in the connector param) and the connected account identifier (the identifier used when the connected account was created).'
+    : '';
+
   return {
     content: [
       {
         type: 'text' as const,
-        text: `Tools${searchDesc ? ` matching ${searchDesc}` : ''} — ${count} total\n\n${body || '(no tools found)'}${pagination}${prev}`,
+        text: `Tools${searchDesc ? ` matching ${searchDesc}` : ''} — ${count} total\n\n${body || '(no tools found)'}${pagination}${prev}${customToolHint}`,
       },
     ],
   };

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -12,18 +12,6 @@ import {
 import { environmentIdSchema } from '../validators/types.js';
 import { TOOLS } from './index.js';
 
-/** Extracts the email claim from a JWT access token (already validated by middleware). */
-function getEmailFromToken(token: string): string | undefined {
-  try {
-    const payload = token.split('.')[1];
-    if (!payload) return undefined;
-    const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString());
-    return decoded.email ?? undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 /** Returns true when the connector identifier looks environment-scoped (custom). */
 function isCustomConnector(connector: string): boolean {
   return connector.includes(':');
@@ -83,6 +71,10 @@ function searchToolsTool(server: McpServer): RegisteredTool {
         .string()
         .optional()
         .describe('Filter by connector identifier as returned by search_connectors (e.g. "GMAIL", "HUBSPOT", "NOTION", "SLACK").'),
+      identifier: z
+        .string()
+        .optional()
+        .describe('The connected account identifier (e.g. a user ID, email, or app-specific key stored by the developer). Required when searching tools for a custom connector. This is the same identifier used when creating the connected account.'),
       query: z
         .string()
         .min(3, 'Query must be at least 3 characters')
@@ -102,7 +94,7 @@ function searchToolsTool(server: McpServer): RegisteredTool {
         .describe('Opaque token from a previous response to fetch the next page.'),
     },
     async (
-      { environmentId, connector, query, summary, pageSize, pageToken },
+      { environmentId, connector, identifier, query, summary, pageSize, pageToken },
       context
     ) => {
       if (!connector && !query) {
@@ -128,7 +120,7 @@ function searchToolsTool(server: McpServer): RegisteredTool {
         return await listToolsMode(
           token,
           environmentDomain,
-          { connector, query, summary },
+          { connector, identifier, query, summary },
           pageSize,
           pageToken
         );
@@ -180,6 +172,7 @@ async function listToolsMode(
   environmentDomain: string,
   filters: {
     connector?: string;
+    identifier?: string;
     query?: string;
     summary?: boolean;
   },
@@ -194,8 +187,15 @@ async function listToolsMode(
   if (connector && isCustomConnector(connector)) {
     // Custom connector: use filter.connector + filter.identifier so the backend
     // resolves the connected account and includes custom MCP tools.
-    const email = getEmailFromToken(token);
-    data = await fetchTools(token, environmentDomain, { connector, identifier: email, query: filters.query }, pageSize, pageToken);
+    if (!filters.identifier) {
+      return {
+        content: [{
+          type: 'text' as const,
+          text: 'An identifier is required when searching tools for a custom connector. Provide the connected account identifier (e.g. user ID, email, or app-specific key used when the connected account was created).',
+        }],
+      };
+    }
+    data = await fetchTools(token, environmentDomain, { connector, identifier: filters.identifier, query: filters.query }, pageSize, pageToken);
     tools = data.tools ?? [];
   } else if (connector) {
     // Standard connector: filter by provider

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -6,7 +6,6 @@ import { logger } from '../lib/logger.js';
 import { ENDPOINTS } from '../types/endpoints.js';
 import {
   AuthInfo,
-  ListAvailableToolsResponse,
   ListToolsResponse,
   ScalekitTool,
 } from '../types/index.js';
@@ -60,7 +59,19 @@ function searchToolsTool(server: McpServer): RegisteredTool {
         .string()
         .optional()
         .describe(
-          'Connected account identifier string. When provided, switches to identifier-scoped mode and lists all tools available for that account.'
+          'Filter by connected account identifier (e.g. "app_google_workspace").'
+        ),
+      connector: z
+        .string()
+        .optional()
+        .describe(
+          'Connector name (e.g. "My Gmail"). When set with identifier, resolves to a specific connected account and includes its custom MCP tools.'
+        ),
+      connectedAccountId: z
+        .string()
+        .optional()
+        .describe(
+          'Connected account ID (e.g. "ca_123"). Alternative to identifier + connector for directly identifying the connected account.'
         ),
       toolNames: z
         .array(z.string())
@@ -80,15 +91,15 @@ function searchToolsTool(server: McpServer): RegisteredTool {
         .describe('Opaque token from a previous response to fetch the next page.'),
     },
     async (
-      { environmentId, query, provider, identifier, toolNames, summary, pageSize, pageToken },
+      { environmentId, query, provider, identifier, connector, connectedAccountId, toolNames, summary, pageSize, pageToken },
       context
     ) => {
-      if (!query && !provider && !identifier && !toolNames?.length) {
+      if (!query && !provider && !identifier && !connector && !connectedAccountId && !toolNames?.length) {
         return {
           content: [
             {
               type: 'text' as const,
-              text: 'At least one search criterion is required: provide a query, provider, identifier, or toolNames.',
+              text: 'At least one search criterion is required: provide a query, provider, identifier, connector, connectedAccountId, or toolNames.',
             },
           ],
         };
@@ -103,20 +114,10 @@ function searchToolsTool(server: McpServer): RegisteredTool {
           environmentId
         );
 
-        if (identifier) {
-          return await listAvailableToolsMode(
-            token,
-            environmentDomain,
-            identifier,
-            pageSize,
-            pageToken
-          );
-        }
-
         return await listToolsMode(
           token,
           environmentDomain,
-          { query, provider, toolNames, summary },
+          { query, provider, identifier, connector, connectedAccountId, toolNames, summary },
           pageSize,
           pageToken
         );
@@ -141,6 +142,9 @@ async function listToolsMode(
   filters: {
     query?: string;
     provider?: string;
+    identifier?: string;
+    connector?: string;
+    connectedAccountId?: string;
     toolNames?: string[];
     summary?: boolean;
   },
@@ -153,6 +157,9 @@ async function listToolsMode(
   if (pageToken) params.set('page_token', pageToken);
   if (filters.query) params.set('filter.query', filters.query);
   if (filters.provider) params.set('filter.provider', filters.provider);
+  if (filters.identifier) params.set('filter.identifier', filters.identifier);
+  if (filters.connector) params.set('filter.connector', filters.connector);
+  if (filters.connectedAccountId) params.set('filter.connected_account_id', filters.connectedAccountId);
   if (filters.summary) params.set('filter.summary', 'true');
   if (filters.toolNames?.length) {
     for (const name of filters.toolNames) {
@@ -188,6 +195,9 @@ async function listToolsMode(
   const searchDesc = [
     filters.query ? `query="${filters.query}"` : null,
     filters.provider ? `provider=${filters.provider}` : null,
+    filters.identifier ? `identifier=${filters.identifier}` : null,
+    filters.connector ? `connector=${filters.connector}` : null,
+    filters.connectedAccountId ? `connected_account_id=${filters.connectedAccountId}` : null,
   ]
     .filter(Boolean)
     .join(', ');
@@ -197,53 +207,6 @@ async function listToolsMode(
       {
         type: 'text' as const,
         text: `Tools${searchDesc ? ` matching ${searchDesc}` : ''} — ${count} total\n\n${body || '(no tools found)'}${pagination}${prev}`,
-      },
-    ],
-  };
-}
-
-async function listAvailableToolsMode(
-  token: string,
-  environmentDomain: string,
-  identifier: string,
-  pageSize: number,
-  pageToken?: string
-) {
-  const params = new URLSearchParams({
-    identifier,
-    page_size: String(pageSize),
-  });
-  if (pageToken) params.set('page_token', pageToken);
-
-  const res = await fetch(
-    `${ENDPOINTS.tools.listAvailable}?${params.toString()}`,
-    { headers: envHeaders(token, environmentDomain) }
-  );
-
-  if (!res.ok) {
-    const errorText = await res.text();
-    logger.error(
-      `Failed to list available tools: ${res.status} ${errorText}`
-    );
-    throw new Error(`Failed to list available tools: ${res.statusText}`);
-  }
-
-  const data = (await res.json()) as ListAvailableToolsResponse;
-  const tools = data.tools ?? [];
-  const body = formatTools(tools);
-  const count = data.total_size ?? tools.length;
-  const pagination = data.next_page_token
-    ? `\n\nNext page token: ${data.next_page_token}`
-    : '\n\nNo more pages.';
-  const prev = data.prev_page_token
-    ? `\nPrevious page token: ${data.prev_page_token}`
-    : '';
-
-  return {
-    content: [
-      {
-        type: 'text' as const,
-        text: `Available tools for identifier "${identifier}" — ${count} total\n\n${body || '(no tools found)'}${pagination}${prev}`,
       },
     ],
   };

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -130,23 +130,17 @@ function searchToolsTool(server: McpServer): RegisteredTool {
   );
 }
 
-async function listToolsMode(
+async function fetchTools(
   token: string,
   environmentDomain: string,
-  filters: {
-    connector?: string;
-    query?: string;
-    summary?: boolean;
-  },
+  apiFilters: { provider?: string; query?: string },
   pageSize: number,
   pageToken?: string
-) {
-  const params = new URLSearchParams({
-    page_size: String(pageSize),
-  });
+): Promise<ListToolsResponse> {
+  const params = new URLSearchParams({ page_size: String(pageSize) });
   if (pageToken) params.set('page_token', pageToken);
-  if (filters.connector) params.set('filter.provider', filters.connector.toUpperCase());
-  if (filters.query) params.set('filter.query', filters.query);
+  if (apiFilters.provider) params.set('filter.provider', apiFilters.provider);
+  if (apiFilters.query) params.set('filter.query', apiFilters.query);
 
   const res = await fetch(
     `${ENDPOINTS.tools.list}?${params.toString()}`,
@@ -159,18 +153,53 @@ async function listToolsMode(
     throw new Error(`Failed to search tools: ${res.statusText}`);
   }
 
-  const data = (await res.json()) as ListToolsResponse;
-  const tools = data.tools ?? [];
-  const count = data.total_size ?? tools.length;
+  return (await res.json()) as ListToolsResponse;
+}
+
+async function listToolsMode(
+  token: string,
+  environmentDomain: string,
+  filters: {
+    connector?: string;
+    query?: string;
+    summary?: boolean;
+  },
+  pageSize: number,
+  pageToken?: string
+) {
+  const connector = filters.connector?.toUpperCase();
+  let data: ListToolsResponse;
+  let tools: ScalekitTool[];
+  let clientFiltered = false;
+
+  if (connector) {
+    // Try exact match first
+    data = await fetchTools(token, environmentDomain, { provider: connector, query: filters.query }, pageSize, pageToken);
+    tools = data.tools ?? [];
+
+    // If exact match returns nothing, fall back to client-side partial match
+    if (tools.length === 0 && !pageToken) {
+      data = await fetchTools(token, environmentDomain, { query: filters.query }, pageSize);
+      tools = (data.tools ?? []).filter(
+        (t) => t.provider?.toUpperCase().includes(connector)
+      );
+      clientFiltered = true;
+    }
+  } else {
+    data = await fetchTools(token, environmentDomain, { query: filters.query }, pageSize, pageToken);
+    tools = data.tools ?? [];
+  }
+
+  const count = clientFiltered ? tools.length : (data.total_size ?? tools.length);
 
   const body = filters.summary
     ? formatToolsSummary(tools)
     : formatToolsFull(tools);
 
-  const pagination = data.next_page_token
+  const pagination = !clientFiltered && data.next_page_token
     ? `\n\nNext page token: ${data.next_page_token}`
     : '';
-  const prev = data.prev_page_token
+  const prev = !clientFiltered && data.prev_page_token
     ? `\nPrevious page token: ${data.prev_page_token}`
     : '';
 

--- a/src/tools/tool-search.ts
+++ b/src/tools/tool-search.ts
@@ -65,7 +65,7 @@ function searchToolsTool(server: McpServer): RegisteredTool {
       connector: z
         .string()
         .optional()
-        .describe('Filter by connector (e.g. "GOOGLE", "HUBSPOT", "NOTION").'),
+        .describe('Filter by connector identifier as returned by search_connectors (e.g. "GMAIL", "HUBSPOT", "NOTION", "SLACK").'),
       query: z
         .string()
         .min(3, 'Query must be at least 3 characters')

--- a/src/types/endpoints.ts
+++ b/src/types/endpoints.ts
@@ -40,8 +40,11 @@ export const ENDPOINTS = {
     enableById: (id: string) => `${SK_API_BASE_URL}/api/v1/connections/${id}:enable`,
     list: `${SK_API_BASE_URL}/api/v1/connections`,
     connectedAccountsList: `${SK_API_BASE_URL}/api/v1/connected_accounts`,
-    connectedAccountsSearch: `${SK_API_BASE_URL}/api/v1/connected_accounts:search`,
+    listApp: `${SK_API_BASE_URL}/api/v1/connections/app`,
     connectedAccountsMagicLink: `${SK_API_BASE_URL}/api/v1/connected_accounts/magic_link`,
+  },
+  providers: {
+    list: `${SK_API_BASE_URL}/api/v1/providers`,
   },
   tools: {
     list: `${SK_API_BASE_URL}/api/v1/tools`,

--- a/src/types/endpoints.ts
+++ b/src/types/endpoints.ts
@@ -48,7 +48,6 @@ export const ENDPOINTS = {
   },
   tools: {
     list: `${SK_API_BASE_URL}/api/v1/tools`,
-    listAvailable: `${SK_API_BASE_URL}/api/v1/tools/available`,
   },
   oauthAuthorizationServer: `${AUTH_BASE_URL}/resources/${config.authServerId}${OAUTH_AUTHORIZATION_SERVER_PATH}`,
   oauthProtectedResource: `${API_BASE_URL}${OAUTH_PROTECTED_RESOURCE_PATH}`,

--- a/src/types/endpoints.ts
+++ b/src/types/endpoints.ts
@@ -40,7 +40,12 @@ export const ENDPOINTS = {
     enableById: (id: string) => `${SK_API_BASE_URL}/api/v1/connections/${id}:enable`,
     list: `${SK_API_BASE_URL}/api/v1/connections`,
     connectedAccountsList: `${SK_API_BASE_URL}/api/v1/connected_accounts`,
+    connectedAccountsSearch: `${SK_API_BASE_URL}/api/v1/connected_accounts:search`,
     connectedAccountsMagicLink: `${SK_API_BASE_URL}/api/v1/connected_accounts/magic_link`,
+  },
+  tools: {
+    list: `${SK_API_BASE_URL}/api/v1/tools`,
+    listAvailable: `${SK_API_BASE_URL}/api/v1/tools/available`,
   },
   oauthAuthorizationServer: `${AUTH_BASE_URL}/resources/${config.authServerId}${OAUTH_AUTHORIZATION_SERVER_PATH}`,
   oauthProtectedResource: `${API_BASE_URL}${OAUTH_PROTECTED_RESOURCE_PATH}`,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -250,6 +250,25 @@ export interface Provider {
   is_custom_mcp: boolean;
 }
 
+/** App-level connection from GET /api/v1/connections/app (AgentKit connectors set up in the environment). */
+export interface AppConnection {
+  id: string;
+  provider: string;
+  type: string;
+  status: string;
+  enabled: boolean;
+  organization_id: string;
+  provider_key: string;
+  key_id: string;
+  created_at: string;
+}
+
+export interface ListAppConnectionsResponse {
+  connections: AppConnection[];
+  total_size: number;
+  next_page_token: string;
+}
+
 export interface ListProvidersResponse {
   providers: Provider[];
   total_size: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -275,13 +275,6 @@ export interface ListToolsResponse {
   prev_page_token: string;
 }
 
-export interface ListAvailableToolsResponse {
-  tools: ScalekitTool[];
-  total_size: number;
-  next_page_token: string;
-  prev_page_token: string;
-}
-
 export interface CreateConnectionResponse {
   connection: DetailedConnection;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -235,8 +235,23 @@ export interface Resource {
 }
 
 
-export interface SearchConnectedAccountsResponse {
-  connected_accounts: ConnectedAccount[];
+export interface Provider {
+  id: string;
+  identifier: string;
+  display_name: string;
+  description: string;
+  categories: string[];
+  icon_src: string;
+  display_priority: number;
+  coming_soon: boolean;
+  proxy_url: string;
+  proxy_enabled: boolean;
+  is_custom: boolean;
+  is_custom_mcp: boolean;
+}
+
+export interface ListProvidersResponse {
+  providers: Provider[];
   total_size: number;
   next_page_token: string;
   prev_page_token: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -235,6 +235,38 @@ export interface Resource {
 }
 
 
+export interface SearchConnectedAccountsResponse {
+  connected_accounts: ConnectedAccount[];
+  total_size: number;
+  next_page_token: string;
+  prev_page_token: string;
+}
+
+export interface ScalekitTool {
+  id: string;
+  provider: string;
+  definition: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  tags?: string[];
+  is_default?: boolean;
+  updated_at?: string;
+}
+
+export interface ListToolsResponse {
+  tools: ScalekitTool[];
+  tool_names: string[];
+  total_size: number;
+  next_page_token: string;
+  prev_page_token: string;
+}
+
+export interface ListAvailableToolsResponse {
+  tools: ScalekitTool[];
+  total_size: number;
+  next_page_token: string;
+  prev_page_token: string;
+}
+
 export interface CreateConnectionResponse {
   connection: DetailedConnection;
 }


### PR DESCRIPTION
## What

Adds two discovery tools for coding agents using the Scalekit MCP server:

### `search_connectors`
Searches OAuth connectors (connected accounts like Google, Notion, Slack) by keyword.

- **Backing API:** `GET /api/v1/connected_accounts:search` (`SearchConnectedAccounts` RPC)
- **Parameters:** `environmentId` (required), `query` (required, min 3 chars), `connectionId` (optional filter), `pageSize`, `pageToken`
- **Scope:** `env:read`

### `search_tools`
Smart-routing tool that searches available tools (actions) for connectors.

- **Broad search mode:** provide `query` and/or `provider` → calls `GET /api/v1/tools` (`ListTools` RPC)
- **Identifier-scoped mode:** provide `identifier` → calls `GET /api/v1/tools/available` (`ListAvailableTools` RPC)
- **Additional filters:** `toolNames[]`, `summary` (names only), pagination
- **Scope:** `env:read`

## Why

Coding agents relying on the Scalekit MCP server need to discover available connectors and tools in real time. These two tools close that gap.

## Files changed

| File | Change |
|---|---|
| `src/types/endpoints.ts` | Added `connectedAccountsSearch` and `tools.list`/`tools.listAvailable` endpoints |
| `src/types/index.ts` | Added `SearchConnectedAccountsResponse`, `ScalekitTool`, `ListToolsResponse`, `ListAvailableToolsResponse` |
| `src/tools/index.ts` | Added tool definitions + registration |
| `src/tools/connections.ts` | Added `searchConnectorsTool` implementation |
| `src/tools/tool-search.ts` | **New** — `search_tools` implementation with smart routing |