### PR TITLE
Add isError flag to all tool error responses

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -34,6 +34,9 @@ export function envHeaders(
 }
 
 /** Builds the standard MCP text content response. */
-export function textContent(text: string): { content: [{ type: 'text'; text: string }] } {
-  return { content: [{ type: 'text', text }] };
+export function textContent(text: string, opts?: { isError?: boolean }) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    ...(opts?.isError && { isError: true }),
+  };
 }

--- a/src/tools/connections.ts
+++ b/src/tools/connections.ts
@@ -87,6 +87,7 @@ function getEnvironmentConnectionsTool(server: McpServer): RegisteredTool {
       } catch (error) {
         logger.error('Failed to fetch connection details', error);
         return {
+          isError: true,
           content: [{ type: 'text', text: 'Failed to fetch connection details. Please try again later.' }],
         };
       }
@@ -141,6 +142,7 @@ function listConnectedAccountsTool(server: McpServer): RegisteredTool {
       } catch (error) {
         logger.error('Failed to list connected accounts', error);
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -192,6 +194,7 @@ function createConnectedAccountMagicLinkTool(server: McpServer): RegisteredTool 
       } catch (error) {
         logger.error('Failed to create connected account magic link', error);
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -232,6 +235,7 @@ function getOrganizationConnectionsTool(server: McpServer): RegisteredTool {
       } catch (error) {
         logger.error('Failed to fetch connection details', error);
         return {
+          isError: true,
           content: [{ type: 'text', text: 'Failed to fetch connection details. Please try again later.' }],
         };
       }
@@ -266,6 +270,7 @@ function enableConnectionTool(server: McpServer): RegisteredTool {
                     const errorText = await res.text();
                     logger.error(`Failed to enable connection: ${res.status} ${errorText}`);
                     return {
+                        isError: true,
                         content: [
                             {
                                 type: 'text',
@@ -287,6 +292,7 @@ function enableConnectionTool(server: McpServer): RegisteredTool {
             } catch (error) {
                 logger.error(`Failed to enable connection`, error);
                 return {
+                    isError: true,
                     content: [
                         {
                             type: 'text',

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -55,6 +55,7 @@ export function registerDocsTools(server: McpServer) {
       } catch (err) {
         logger.error('Failed to fetch docs for search_docs', { error: err, query });
         return {
+          isError: true,
           content: [{ type: 'text' as const, text: `Failed to retrieve documentation: ${err instanceof Error ? err.message : String(err)}` }],
         };
       }

--- a/src/tools/environments.ts
+++ b/src/tools/environments.ts
@@ -64,6 +64,7 @@ function listEnvironmentsTool(server: McpServer): RegisteredTool {
       } catch (err) {
         logger.error('Failed to fetch environments for list_environments', { error: err });
         return {
+          isError: true,
           content: [{ type: 'text', text: 'Failed to fetch environments. Please try again later.' }],
         };
       }
@@ -89,7 +90,7 @@ function getEnvironmentDetailsTool(server: McpServer): RegisteredTool {
         );
       } catch {
         logger.error(`Failed to fetch environment for get-environment-details: ${environmentId}`);
-        return textContent('Failed to fetch environment. Please check the if environment is correctly set or try again later.');
+        return textContent('Failed to fetch environment. Please check the if environment is correctly set or try again later.', { isError: true });
       }
     });
 }
@@ -132,6 +133,7 @@ function getEnvironmentCredentialsTool(server: McpServer): RegisteredTool {
       } catch (err) {
         logger.error('Failed to fetch credentials for get_environment_credentials', { error: err });
         return {
+          isError: true,
           content: [{ type: 'text', text: 'Failed to fetch environment credentials. Please try again later.' }],
         };
       }
@@ -209,13 +211,13 @@ function createEnvironmentRolesTool(server: McpServer): RegisteredTool {
         if (res.status > 399 && res.status < 500) {
           const errBody = await res.json().catch(() => ({}));
           logger.error('Failed to create role', { status: res.statusText, body: errBody });
-          return textContent('Failed to create role. Please check if the environment is correctly set or if this role already exist or try again later.');
+          return textContent('Failed to create role. Please check if the environment is correctly set or if this role already exist or try again later.', { isError: true });
         }
         const data = (await res.json()) as { role: Role };
         role = data.role;
       } catch (err) {
         logger.error('Failed to create environment role', { error: err });
-        return textContent('Failed to create role. Please check if the environment is correctly set or try again later.');
+        return textContent('Failed to create role. Please check if the environment is correctly set or try again later.', { isError: true });
       }
 
       return textContent(
@@ -251,13 +253,13 @@ function createEnvironmentScopeTool(server: McpServer): RegisteredTool {
         if (res.status > 399 && res.status < 500) {
           const errBody = await res.json().catch(() => ({}));
           logger.error('Failed to create scope', { status: res.statusText, body: errBody });
-          return textContent('Failed to create scope. Please check if the environment is correctly set or if this scope already exist or try again later.');
+          return textContent('Failed to create scope. Please check if the environment is correctly set or if this scope already exist or try again later.', { isError: true });
         }
         const data = (await res.json()) as { scope: Scope };
         scope = data.scope;
       } catch (err) {
         logger.error('Failed to create environment scope', { error: err });
-        return textContent('Failed to create scope. Please check if the environment is correctly set or try again later.');
+        return textContent('Failed to create scope. Please check if the environment is correctly set or try again later.', { isError: true });
       }
 
       return textContent(`Scope created successfully:\nName: ${scope.name}\nDescription: ${scope.description}`);
@@ -355,7 +357,7 @@ function listRedirectUrisTool(server: McpServer): RegisteredTool {
         };
       } catch (err) {
         logger.error('Failed to list redirect URIs', { error: err });
-        return textContent('Failed to fetch redirect URIs. Please try again later.');
+        return textContent('Failed to fetch redirect URIs. Please try again later.', { isError: true });
       }
     });
 }
@@ -391,7 +393,7 @@ function addRedirectUriTool(server: McpServer): RegisteredTool {
 
         if (!res.ok) {
           logger.error('Failed to add redirect URI', { status: res.status });
-          return textContent('Failed to add redirect URI. Please try again later.');
+          return textContent('Failed to add redirect URI. Please try again later.', { isError: true });
         }
 
         return textContent(
@@ -399,7 +401,7 @@ function addRedirectUriTool(server: McpServer): RegisteredTool {
         );
       } catch (err) {
         logger.error('Failed to add redirect URI', { error: err });
-        return textContent('Failed to add redirect URI. Please try again later.');
+        return textContent('Failed to add redirect URI. Please try again later.', { isError: true });
       }
     });
 }
@@ -435,7 +437,7 @@ function removeRedirectUriTool(server: McpServer): RegisteredTool {
 
         if (!res.ok) {
           logger.error('Failed to remove redirect URI', { status: res.status });
-          return textContent('Failed to remove redirect URI. Please try again later.');
+          return textContent('Failed to remove redirect URI. Please try again later.', { isError: true });
         }
 
         return textContent(
@@ -445,7 +447,7 @@ function removeRedirectUriTool(server: McpServer): RegisteredTool {
         );
       } catch (err) {
         logger.error('Failed to remove redirect URI', { error: err });
-        return textContent('Failed to remove redirect URI. Please try again later.');
+        return textContent('Failed to remove redirect URI. Please try again later.', { isError: true });
       }
     });
 }
@@ -473,13 +475,13 @@ function setInitiateLoginUriTool(server: McpServer): RegisteredTool {
 
         if (!res.ok) {
           logger.error('Failed to set initiate login URI', { status: res.status });
-          return textContent('Failed to set initiate login URI. Please try again later.');
+          return textContent('Failed to set initiate login URI. Please try again later.', { isError: true });
         }
 
         return textContent(`Initiate login URI set successfully: ${uri}`);
       } catch (err) {
         logger.error('Failed to set initiate login URI', { error: err });
-        return textContent('Failed to set initiate login URI. Please try again later.');
+        return textContent('Failed to set initiate login URI. Please try again later.', { isError: true });
       }
     });
 }
@@ -504,13 +506,13 @@ function removeInitiateLoginUriTool(server: McpServer): RegisteredTool {
 
         if (!res.ok) {
           logger.error('Failed to remove initiate login URI', { status: res.status });
-          return textContent('Failed to remove initiate login URI. Please try again later.');
+          return textContent('Failed to remove initiate login URI. Please try again later.', { isError: true });
         }
 
         return textContent('Initiate login URI removed successfully.');
       } catch (err) {
         logger.error('Failed to remove initiate login URI', { error: err });
-        return textContent('Failed to remove initiate login URI. Please try again later.');
+        return textContent('Failed to remove initiate login URI. Please try again later.', { isError: true });
       }
     });
 }
@@ -546,7 +548,7 @@ function addPostLogoutRedirectUriTool(server: McpServer): RegisteredTool {
 
         if (!res.ok) {
           logger.error('Failed to add post-logout redirect URI', { status: res.status });
-          return textContent('Failed to add post-logout redirect URI. Please try again later.');
+          return textContent('Failed to add post-logout redirect URI. Please try again later.', { isError: true });
         }
 
         return textContent(
@@ -554,7 +556,7 @@ function addPostLogoutRedirectUriTool(server: McpServer): RegisteredTool {
         );
       } catch (err) {
         logger.error('Failed to add post-logout redirect URI', { error: err });
-        return textContent('Failed to add post-logout redirect URI. Please try again later.');
+        return textContent('Failed to add post-logout redirect URI. Please try again later.', { isError: true });
       }
     });
 }
@@ -590,7 +592,7 @@ function removePostLogoutRedirectUriTool(server: McpServer): RegisteredTool {
 
         if (!res.ok) {
           logger.error('Failed to remove post-logout redirect URI', { status: res.status });
-          return textContent('Failed to remove post-logout redirect URI. Please try again later.');
+          return textContent('Failed to remove post-logout redirect URI. Please try again later.', { isError: true });
         }
 
         return textContent(
@@ -600,7 +602,7 @@ function removePostLogoutRedirectUriTool(server: McpServer): RegisteredTool {
         );
       } catch (err) {
         logger.error('Failed to remove post-logout redirect URI', { error: err });
-        return textContent('Failed to remove post-logout redirect URI. Please try again later.');
+        return textContent('Failed to remove post-logout redirect URI. Please try again later.', { isError: true });
       }
     });
 }

--- a/src/tools/organizations.ts
+++ b/src/tools/organizations.ts
@@ -64,6 +64,7 @@ function createOrganizationTool(server: McpServer): RegisteredTool {
         };
       } catch {
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -136,6 +137,7 @@ function listOrganizationsTool(server: McpServer): RegisteredTool {
       } catch (error) {
         logger.error(`Failed to fetch organizations`, error);
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -188,6 +190,7 @@ function getOrganizationDetailsTool(server: McpServer): RegisteredTool {
       } catch (error) {
         logger.error(`Failed to fetch organization details`, error);
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -235,6 +238,7 @@ function generateAdminPortalLinkTool(server: McpServer): RegisteredTool {
         };
       } catch {
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -263,7 +267,7 @@ function createOrganizationUserTool(server: McpServer): RegisteredTool {
 
       const emailError = validateEmail(email);
       if (emailError !== null) {
-        return { content: [{ type: 'text', text: emailError }] };
+        return { isError: true, content: [{ type: 'text', text: emailError }] };
       }
 
       try {
@@ -287,6 +291,7 @@ function createOrganizationUserTool(server: McpServer): RegisteredTool {
         if (!res.ok) {
           logger.error('Failed to create organization user', { status: res.statusText });
           return {
+            isError: true,
             content: [{ type: 'text', text: 'Failed to create organization user. Please try again.' }],
           };
         }
@@ -302,6 +307,7 @@ function createOrganizationUserTool(server: McpServer): RegisteredTool {
       } catch (error) {
         logger.error(`Failed to create organization user`, error);
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -376,6 +382,7 @@ function listOrganizationUsersTool(server: McpServer): RegisteredTool {
       } catch (error) {
         logger.error(`Failed to fetch organization users`, error);
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -443,6 +450,7 @@ function updateOrganizationSettingsTool(server: McpServer): RegisteredTool {
           error
         );
         return {
+          isError: true,
           content: [
             {
               type: 'text',

--- a/src/tools/resource.ts
+++ b/src/tools/resource.ts
@@ -77,6 +77,7 @@ function listMcpServersTool(server: McpServer): RegisteredTool {
       } catch (error) {
         logger.error('Failed to fetch MCP servers', error);
         return {
+          isError: true,
           content: [{ type: 'text', text: 'Failed to fetch MCP servers. Please try again later.' }],
         };
       }
@@ -103,7 +104,7 @@ function registerMcpServerTool(server: McpServer): RegisteredTool {
 
       const urlError = validateUrls([mcpServerUrl]);
       if (urlError !== null) {
-        return { content: [{ type: 'text', text: urlError }] };
+        return { isError: true, content: [{ type: 'text', text: urlError }] };
       }
 
       const environmentDomain = await getEnvironmentDomain(token, environmentId);
@@ -120,6 +121,7 @@ function registerMcpServerTool(server: McpServer): RegisteredTool {
       } else {
         logger.warn(`Failed to fetch environment roles: ${JSON.stringify(scopesRes.json())}`);
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -131,6 +133,7 @@ function registerMcpServerTool(server: McpServer): RegisteredTool {
     } catch (err) {
       logger.warn(`Error fetching environment roles`, err);
         return {
+            isError: true,
             content: [
             {
                 type: 'text',
@@ -149,6 +152,7 @@ function registerMcpServerTool(server: McpServer): RegisteredTool {
     } catch (e) {
       logger.error(`Invalid MCP Server URL: ${mcpServerUrl}`, e);
       return {
+        isError: true,
         content: [
           {
             type: 'text',
@@ -202,6 +206,7 @@ function registerMcpServerTool(server: McpServer): RegisteredTool {
         } else {
           logger.error(`Failed to register mcp server: ${res.statusText}.`);
           return {
+            isError: true,
             content: [
               {
                 type: 'text',
@@ -213,6 +218,7 @@ function registerMcpServerTool(server: McpServer): RegisteredTool {
       } catch (error) {
         logger.error(`Failed to register mcp server`, error);
         return {
+          isError: true,
           content: [
             {
               type: 'text',
@@ -246,7 +252,7 @@ function updateMcpServerTool(server: McpServer): RegisteredTool {
             if (mcpServerUrl) {
               const urlError = validateUrls([mcpServerUrl]);
               if (urlError !== null) {
-                return { content: [{ type: 'text', text: urlError }] };
+                return { isError: true, content: [{ type: 'text', text: urlError }] };
               }
             }
 
@@ -270,6 +276,7 @@ function updateMcpServerTool(server: McpServer): RegisteredTool {
 
             if (Object.keys(updatePayload).length === 0) {
                 return {
+                    isError: true,
                     content: [
                         {
                             type: 'text',
@@ -298,6 +305,7 @@ function updateMcpServerTool(server: McpServer): RegisteredTool {
                 } else {
                     logger.error(`Failed to update mcp server: ${res.statusText}.`);
                     return {
+                        isError: true,
                         content: [
                             {
                                 type: 'text',
@@ -309,6 +317,7 @@ function updateMcpServerTool(server: McpServer): RegisteredTool {
             } catch (error) {
                 logger.error(`Failed to update mcp server`, error);
                 return {
+                    isError: true,
                     content: [
                         {
                             type: 'text',
@@ -353,6 +362,7 @@ function switchMcpAuthToScalekitTool(server: McpServer): RegisteredTool {
                 } else {
                     logger.error(`Failed to switch MCP server auth: ${res.statusText}.`);
                     return {
+                        isError: true,
                         content: [
                             {
                                 type: 'text',
@@ -364,6 +374,7 @@ function switchMcpAuthToScalekitTool(server: McpServer): RegisteredTool {
             } catch (error) {
                 logger.error(`Failed to switch MCP server auth`, error);
                 return {
+                    isError: true,
                     content: [
                         {
                             type: 'text',

--- a/src/tools/workspace.ts
+++ b/src/tools/workspace.ts
@@ -53,6 +53,7 @@ function listWorkspaceMembers(server: McpServer): RegisteredTool {
             } catch {
                 logger.error(`Failed to fetch workspace members`);
                 return {
+                    isError: true,
                     content: [
                         {
                             type: 'text',
@@ -79,6 +80,7 @@ function inviteWorkspaceMember(server: McpServer): RegisteredTool {
             var res = validateEmail(email)
             if (res !== null) {
                 return {
+                    isError: true,
                     content: [
                         {
                             type: 'text',
@@ -107,6 +109,7 @@ function inviteWorkspaceMember(server: McpServer): RegisteredTool {
                         : 'Unknown error';
                     logger.error(`Failed to invite workspace member: ${errorMessage}. if the user already exist then check if the user has accepted the invitation.`);
                     return {
+                        isError: true,
                         content: [
                             {
                                 type: 'text',
@@ -130,6 +133,7 @@ function inviteWorkspaceMember(server: McpServer): RegisteredTool {
             } catch {
                 logger.error(`Failed to invite workspace members`);
                 return {
+                    isError: true,
                     content: [
                         {
                             type: 'text',


### PR DESCRIPTION
## Summary

Per the [MCP spec](https://modelcontextprotocol.io), tool results should include `isError: true` when the tool encounters an error. This lets the model structurally distinguish "the API call failed" from "the search returned zero results" — without it, errors are indistinguishable from normal empty responses.

This was missing across **all** tools in the server.

## Changes

- **`src/lib/api.ts`** — Updated `textContent()` helper to accept optional `{ isError: true }` so callers can signal errors without restructuring their return
- **`src/tools/environments.ts`** — 18 error returns updated (roles, scopes, redirect URIs, initiate login URIs, post-logout URIs)
- **`src/tools/resource.ts`** — 10 error returns updated (MCP server CRUD, URL validation, scope fetching)
- **`src/tools/organizations.ts`** — 8 error returns updated (org CRUD, users, settings, portal links)
- **`src/tools/connections.ts`** — 6 error returns updated (connections, connected accounts, magic links)
- **`src/tools/workspace.ts`** — 4 error returns updated (members, invitations, validation)
- **`src/tools/docs.ts`** — 1 error return updated (doc search)

## Testing

- `npm run build` passes cleanly
- No runtime behavior change for success paths; error paths now include the `isError` flag in tool results