### PR TITLE
[SK-613] chore(deps): bump yaml to 2.9.0 and @types/node to 20.19.43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,14 +17,14 @@
         "jsonwebtoken": ">=9.0.3",
         "node-fetch": "^3.3.2",
         "winston": "^3.10.0",
-        "yaml": "^2.8.3",
+        "yaml": "^2.9.0",
         "zod": "^3.25.57"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": ">=9.0.3",
-        "@types/node": "^20.11.19",
+        "@types/node": "^20.19.43",
         "typescript": "^5.4.5"
       }
     },
@@ -254,9 +254,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.31.tgz",
-      "integrity": "sha512-5jsi0wpncvTD33Sh1UCgacK37FFwDn+EG7wCmEvs62fCvBL+n8/76cAYDok21NF6+jaVWIqKwCZyX7Vbu8eB3A==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1969,9 +1969,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
     "jsonwebtoken": ">=9.0.3",
     "node-fetch": "^3.3.2",
     "winston": "^3.10.0",
-    "yaml": "^2.8.3",
+    "yaml": "^2.9.0",
     "zod": "^3.25.57"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": ">=9.0.3",
-    "@types/node": "^20.11.19",
+    "@types/node": "^20.19.43",
     "typescript": "^5.4.5"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

Bumps two low-risk dependencies as part of routine maintenance.

Linear: [SK-613](https://linear.app/scalekit/issue/SK-613/choredeps-bump-2-low-risk-deps-yaml-typesnode)

## Changes

| Package | From | To | Risk |
|---|---|---|---|
| `yaml` | 2.8.3 | 2.9.0 | Low |
| `@types/node` | 20.19.31 | 20.19.43 | Low |

## Notes

- **yaml 2.8.3 → 2.9.0**: Minor update; no breaking changes, adds fixes and improvements to YAML parsing/stringification.
- **@types/node 20.19.31 → 20.19.43**: Patch update to Node.js TypeScript type stubs; purely type-level, no runtime impact.

## Test Results

- `npm run build` (TypeScript compilation): ✅ Pass — no type errors introduced.

---
_Generated by [Claude Code](https://claude.ai/code/session_018S4sLtf5CLGGiSwkS9J1WU)_