### PR TITLE
[SK-614] chore(deps): bump @modelcontextprotocol/sdk from 1.27.1 to 1.29.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@scalekit-sdk/node": ">=2.2.2",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@scalekit-sdk/node": ">=2.2.2",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
## Summary

Bumps the core MCP framework SDK by two minor versions.

Linear: [SK-614](https://linear.app/scalekit/issue/SK-614/choredeps-bump-modelcontextprotocolsdk-from-1271-to-1290)

## Changes

| Package | From | To | Risk |
|---|---|---|---|
| `@modelcontextprotocol/sdk` | 1.27.1 | 1.29.0 | Medium |

## Notes

- Minor version bump within the current `^1.27.1` semver range.
- This is the foundational MCP framework; medium risk because it is imported throughout the server.
- No API breaking changes expected for a minor bump.

## Test Results

- `npm run build` (TypeScript compilation): ✅ Pass — no type errors introduced.

---
_Generated by [Claude Code](https://claude.ai/code/session_018S4sLtf5CLGGiSwkS9J1WU)_