### PR TITLE
[SK-615] chore(deps): bump @scalekit-sdk/node from 2.2.2 to 2.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@scalekit-sdk/node": ">=2.2.2",
+        "@scalekit-sdk/node": "^2.6.2",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^5.2.1",
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@scalekit-sdk/node": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@scalekit-sdk/node/-/node-2.2.2.tgz",
-      "integrity": "sha512-jICjCCztwmN3s3u9nUSEEnXGqX3f/jc4ndM/YRaBXosmWQSnE68LA4Hl03PUWRmjFJ6wizQn0bOg50NLvfdq1w==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@scalekit-sdk/node/-/node-2.6.2.tgz",
+      "integrity": "sha512-v5C7xXCIrnoenNCL0IcvZRBB/VQEfZYEfqUfilZyeqrbEGhKRc6Xd2bhzE3vA8gq5qswdgbvN0DshEkvqsAU0A==",
       "license": "ISC",
       "dependencies": {
         "@bufbuild/protobuf": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@scalekit-sdk/node": ">=2.2.2",
+    "@scalekit-sdk/node": "^2.6.2",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^5.2.1",


### PR DESCRIPTION
## Summary

Bumps the Scalekit Node.js auth/identity SDK by four minor versions.

Linear: [SK-615](https://linear.app/scalekit/issue/SK-615/choredeps-bump-scalekit-sdknode-from-222-to-262)

## Changes

| Package | From | To | Risk |
|---|---|---|---|
| `@scalekit-sdk/node` | 2.2.2 | 2.6.2 | Medium |

## Notes

- Minor version bump within the current `>=2.2.2` semver range.
- Core auth SDK used throughout the server for SSO, SCIM, and directory sync operations.
- Picks up bug fixes and new API capabilities across four minor releases.

## Test Results

- `npm run build` (TypeScript compilation): ✅ Pass — no type errors introduced.

---
_Generated by [Claude Code](https://claude.ai/code/session_018S4sLtf5CLGGiSwkS9J1WU)_