### PR TITLE
[SK-619] chore(deps): bump dotenv from 16.6.1 to 17.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@scalekit-sdk/node": "^2.6.2",
         "cors": "^2.8.5",
-        "dotenv": "^16.4.5",
+        "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "jsonwebtoken": ">=9.0.3",
         "node-fetch": "^3.3.2",
@@ -607,9 +607,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@scalekit-sdk/node": "^2.6.2",
     "cors": "^2.8.5",
-    "dotenv": "^16.4.5",
+    "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "jsonwebtoken": ">=9.0.3",
     "node-fetch": "^3.3.2",


### PR DESCRIPTION
## Summary

Major version bump for dotenv. Public API is unchanged.

Linear: [SK-619](https://linear.app/scalekit/issue/SK-619/choredeps-bump-dotenv-from-1661-to-1742)

## Changes

| Package | From | To | Risk |
|---|---|---|---|
| `dotenv` | 16.6.1 | 17.4.2 | Medium |

## Notes

- Major version bump; requires Node.js 18+ (project uses Node 20 ✅).
- `dotenv.config()` and `process.env` usage are unchanged — no code changes needed.
- Manifest range updated from `^16.4.5` to `^17.4.2`.

## Test Results

- `npm run build` (TypeScript compilation): ✅ Pass — no type errors introduced.

---
_Generated by [Claude Code](https://claude.ai/code/session_018S4sLtf5CLGGiSwkS9J1WU)_