### PR TITLE
[SK-620] chore(deps): bump typescript from 5.9.3 to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/express": "^5.0.6",
         "@types/jsonwebtoken": ">=9.0.3",
         "@types/node": "^20.19.43",
-        "typescript": "^5.4.5"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -1838,9 +1838,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": ">=9.0.3",
     "@types/node": "^20.19.43",
-    "typescript": "^5.4.5"
+    "typescript": "^6.0.3"
   },
   "overrides": {
     "hono": "4.12.7",


### PR DESCRIPTION
## Summary

Major TypeScript compiler upgrade. Build passes cleanly with no source changes required.

Linear: [SK-620](https://linear.app/scalekit/issue/SK-620/choredeps-bump-typescript-from-593-to-603)

## Changes

| Package | From | To | Risk |
|---|---|---|---|
| `typescript` | 5.9.3 | 6.0.3 | High |

## Notes

- Major version bump; manifest range updated from `^5.4.5` to `^6.0.3`.
- TS6 introduces stricter narrowing, updated module resolution, and removes some deprecated options.
- **No source code changes were needed** — the existing codebase compiled cleanly under TS6.

## Test Results

- `npm run build` (TypeScript compilation): ✅ Pass — zero errors with TypeScript 6.

---
_Generated by [Claude Code](https://claude.ai/code/session_018S4sLtf5CLGGiSwkS9J1WU)_