### PR TITLE
[SK-664] chore(deps): bump @types/node from ^20.19.43 to ^25.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/jsonwebtoken": ">=9.0.3",
-        "@types/node": "^20.19.43",
+        "@types/node": "^25.9.3",
         "typescript": "^6.0.3"
       }
     },
@@ -246,13 +246,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/qs": {
@@ -1852,9 +1852,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": ">=9.0.3",
-    "@types/node": "^20.19.43",
+    "@types/node": "^25.9.3",
     "typescript": "^6.0.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

- Upgrades `@types/node` from `^20.19.43` → `^25.9.3`
- Dev dependency only — no runtime or behavioral changes
- `npm run build` passes cleanly with zero type errors

## Details

| Package | From | To | Risk |
|---------|------|----|------|
| `@types/node` | `^20.19.43` | `^25.9.3` | Medium |

Linear: [SK-664](https://linear.app/scalekit/issue/SK-664/choredeps-bump-typesnode-to-2593)

## Test plan

- [x] `npm run build` — passes with no errors
- [x] No source file changes required; type definitions are fully compatible with the codebase
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_018S4sLtf5CLGGiSwkS9J1WU)_