### PR TITLE
Add PostHog analytics instrumentation to MCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@posthog/mcp": "^0.8.0",
         "@scalekit-sdk/node": "2.6.3",
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "jsonwebtoken": ">=9.0.3",
         "node-fetch": "^3.3.2",
+        "posthog-node": "^5.40.0",
         "winston": "^3.10.0",
         "yaml": "^2.9.0",
         "zod": "^4.4.3"
@@ -127,6 +129,37 @@
           "optional": false
         }
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.39.6",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.39.6.tgz",
+      "integrity": "sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.392.0"
+      }
+    },
+    "node_modules/@posthog/mcp": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@posthog/mcp/-/mcp-0.8.0.tgz",
+      "integrity": "sha512-yfezp5z1JSALRfz3/ZCt/eqTtfTd05cC2piYXeO8C1HqganMtdPioZUkgbDjFzvUdiLMF+C6Tg2qgvd/cABZaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.39.6"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": ">=1.26.0",
+        "posthog-node": "^5.0.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.392.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.392.1.tgz",
+      "integrity": "sha512-Qg6Gl7/1vlr8+gPtBi5gwnLgAgiyFoKOVmTvTtDcvya9cpTwZfna7rQmkGQ4B63CunUYNNbOlqcwiUwUDyTK6w==",
+      "license": "MIT"
     },
     "node_modules/@scalekit-sdk/node": {
       "version": "2.6.3",
@@ -1499,6 +1532,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.40.0.tgz",
+      "integrity": "sha512-DrLfHuauO0W6qruF80iqr5JdmLysef74XzOB4eh36oRLRhxCySLraTqsi2Pj161LZnp9/JNdRDxwT8ei8VK2YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.39.6"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
       }
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -14,12 +14,14 @@
   "license": "ISC",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@posthog/mcp": "^0.8.0",
     "@scalekit-sdk/node": "2.6.3",
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "jsonwebtoken": ">=9.0.3",
     "node-fetch": "^3.3.2",
+    "posthog-node": "^5.40.0",
     "winston": "^3.10.0",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -16,4 +16,5 @@ export const config = {
   skEnvUrl: process.env.SK_ENV_URL || '',
   skClientId: process.env.SK_CLIENT_ID || '',
   skClientSecret: process.env.SK_CLIENT_SECRET || '',
+  posthogApiKey: process.env.POSTHOG_API_KEY ?? '',
 };

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,42 @@
+import { instrument } from '@posthog/mcp';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import jwt from 'jsonwebtoken';
+import { PostHog } from 'posthog-node';
+import { config } from '../config/config.js';
+
+export const posthog = config.posthogApiKey
+  ? new PostHog(config.posthogApiKey, { host: 'https://us.i.posthog.com' })
+  : null;
+
+interface AccessTokenClaims {
+  sub:  string;
+  xoid: string;
+}
+
+function decodeClaims(extra: unknown): AccessTokenClaims | null {
+  const token = (extra as any)?.authInfo?.token ?? null;
+  if (!token) return null;
+  return jwt.decode(token) as AccessTokenClaims | null;
+}
+
+export function instrumentServer(server: McpServer): void {
+  if (!posthog) return;
+
+  instrument(server.server, posthog, {
+    enableConversationId:       true,
+    reportMissing:              true,
+    enableExceptionAutocapture: true,
+
+    identify: async (_request, extra) => {
+      const claims = decodeClaims(extra);
+      if (!claims?.sub) return null;
+
+      return {
+        distinctId: claims.sub,
+        groups: {
+          workspace: claims.xoid,
+        },
+      };
+    },
+  });
+}

--- a/src/scalekit.ts
+++ b/src/scalekit.ts
@@ -58,11 +58,11 @@ app.use(express.json());
 const scalekit = new Scalekit(config.skEnvUrl, config.skClientId, config.skClientSecret);
 
 (async () => {
-  instrumentServer(server);
   registerTools(server)
   logger.info('Registered tools successfully');
   registerResources(server);
   logger.info('Registered resources successfully');
+  instrumentServer(server);
 
   app.use(async (req, res, next) => {
     try {

--- a/src/scalekit.ts
+++ b/src/scalekit.ts
@@ -3,6 +3,7 @@ import { Scalekit, TokenValidationOptions } from '@scalekit-sdk/node';
 import cors from 'cors';
 import express from 'express';
 import { config } from './config/config.js';
+import { instrumentServer, posthog } from './lib/analytics.js';
 import { oauthProtectedResourceHandler } from './lib/auth.js';
 import { logger } from './lib/logger.js';
 import { setupTransportRoutes } from './lib/transport.js';
@@ -57,6 +58,7 @@ app.use(express.json());
 const scalekit = new Scalekit(config.skEnvUrl, config.skClientId, config.skClientSecret);
 
 (async () => {
+  instrumentServer(server);
   registerTools(server)
   logger.info('Registered tools successfully');
   registerResources(server);
@@ -108,4 +110,9 @@ const scalekit = new Scalekit(config.skEnvUrl, config.skClientId, config.skClien
   logger.debug('Transport routes set up completed');
 
   app.listen(PORT, () => console.log(`MCP server running on http://localhost:${PORT}`));
+
+  process.on('SIGTERM', async () => {
+    if (posthog) await posthog.shutdown();
+    process.exit(0);
+  });
 })();


### PR DESCRIPTION
## Summary
This PR adds PostHog analytics instrumentation to the MCP server, enabling tracking of server events and user interactions with automatic identification based on JWT claims.

## Key Changes
- **New analytics module** (`src/lib/analytics.ts`): 
  - Initializes PostHog client with configuration from environment variables
  - Implements JWT token decoding to extract user identity (`sub`) and workspace (`xoid`) claims
  - Provides `instrumentServer()` function to attach PostHog instrumentation to the MCP server with automatic exception capture and conversation tracking

- **Server integration** (`src/scalekit.ts`):
  - Calls `instrumentServer()` during server initialization
  - Adds graceful shutdown handler for PostHog to flush pending events on SIGTERM

- **Configuration** (`src/config/config.ts`):
  - Added `posthogApiKey` configuration option from `POSTHOG_API_KEY` environment variable

- **Dependencies** (`package.json`):
  - Added `@posthog/mcp` for MCP server instrumentation
  - Added `posthog-node` for PostHog client functionality

## Implementation Details
- PostHog client is conditionally initialized only when `POSTHOG_API_KEY` is provided
- User identification is extracted from JWT tokens in the request context, mapping to PostHog's `distinctId` and workspace grouping
- Analytics collection is non-blocking and includes automatic exception capture and conversation ID tracking
- Proper cleanup ensures PostHog events are flushed before process termination

https://claude.ai/code/session_01KXtiQEG4yr2q2G577FgzdA